### PR TITLE
feat: 서비스 전체 도메인 설계

### DIFF
--- a/src/main/java/com/nexters/phochak/domain/BaseTime.java
+++ b/src/main/java/com/nexters/phochak/domain/BaseTime.java
@@ -1,0 +1,22 @@
+package com.nexters.phochak.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/nexters/phochak/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/domain/Hashtag.java
@@ -1,0 +1,30 @@
+package com.nexters.phochak.domain;
+
+import lombok.Builder;
+
+import javax.persistence.*;
+
+@Entity
+@Table(indexes = @Index(name = "idx_hashtag", columnList = "tag"))
+public class Hashtag {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name="TAG_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="POST_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Post post;
+
+    private String tag;
+
+    public Hashtag() {
+    }
+
+    @Builder
+    public Hashtag(Post post, String tag) {
+        this.post = post;
+        this.tag = tag;
+    }
+}

--- a/src/main/java/com/nexters/phochak/domain/Phochak.java
+++ b/src/main/java/com/nexters/phochak/domain/Phochak.java
@@ -1,0 +1,31 @@
+package com.nexters.phochak.domain;
+
+import lombok.Builder;
+
+import javax.persistence.*;
+
+@Entity
+public class Phochak extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name="PHOCHAK_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="POST_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Post post;
+
+    public Phochak() {
+    }
+
+    @Builder
+    public Phochak(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/nexters/phochak/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/domain/Post.java
@@ -1,0 +1,39 @@
+package com.nexters.phochak.domain;
+
+import com.nexters.phochak.specification.PostCategory;
+import lombok.Builder;
+
+import javax.persistence.*;
+
+@Entity
+public class Post extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name="POST_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @OneToOne
+    @JoinColumn(name="SHORTS_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Shorts shorts;
+
+    private Long view;
+
+    @Enumerated(EnumType.STRING)
+    private PostCategory postCategory;
+
+    public Post() {
+    }
+
+    @Builder
+    public Post(User user, Shorts shorts, Long view, PostCategory postCategory) {
+        this.user = user;
+        this.shorts = shorts;
+        this.view = view;
+        this.postCategory = postCategory;
+    }
+}

--- a/src/main/java/com/nexters/phochak/domain/PostReport.java
+++ b/src/main/java/com/nexters/phochak/domain/PostReport.java
@@ -1,0 +1,42 @@
+package com.nexters.phochak.domain;
+
+import com.nexters.phochak.specification.ReportCategory;
+import lombok.Builder;
+
+import javax.persistence.*;
+
+@Entity
+public class PostReport {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name="POST_REPORT_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="POST_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="REPORTER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User reporter;
+
+    @Enumerated(EnumType.STRING)
+    private ReportCategory reportCategory;
+
+    private String title;
+
+    private String content;
+
+    public PostReport() {
+    }
+
+    @Builder
+    public PostReport(Post post, User reporter, ReportCategory reportCategory, String title, String content) {
+        this.post = post;
+        this.reporter = reporter;
+        this.reportCategory = reportCategory;
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/nexters/phochak/domain/Shorts.java
+++ b/src/main/java/com/nexters/phochak/domain/Shorts.java
@@ -1,0 +1,35 @@
+package com.nexters.phochak.domain;
+
+import lombok.Builder;
+
+import javax.persistence.*;
+
+@Entity
+public class Shorts {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name="SHORTS_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="POST_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private Post post;
+
+    private String videoUrl;
+
+    private String extension;
+
+    private Long length;
+
+    public Shorts() {
+    }
+
+    @Builder
+    public Shorts(Post post, String videoUrl, String extension, Long length) {
+        this.post = post;
+        this.videoUrl = videoUrl;
+        this.extension = extension;
+        this.length = length;
+    }
+}

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -1,0 +1,12 @@
+package com.nexters.phochak.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @Column(name="USER_ID")
+    private Long id;
+}

--- a/src/main/java/com/nexters/phochak/specification/PostCategory.java
+++ b/src/main/java/com/nexters/phochak/specification/PostCategory.java
@@ -1,0 +1,6 @@
+package com.nexters.phochak.specification;
+
+public enum PostCategory {
+    RESTAURANT,
+    TOUR
+}

--- a/src/main/java/com/nexters/phochak/specification/ReportCategory.java
+++ b/src/main/java/com/nexters/phochak/specification/ReportCategory.java
@@ -1,0 +1,4 @@
+package com.nexters.phochak.specification;
+
+public enum ReportCategory {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,4 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.jdbc.Driver
----
-spring:
   config:
     activate:
       on-profile: local
@@ -10,6 +6,13 @@ spring:
     url: jdbc:mysql://localhost:3306/phochak
     username: phochak
     password: qpdjrmflftm
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
 ---
 spring:
   config:
@@ -19,3 +22,6 @@ spring:
     url: jdbc:mysql://realdb_address
     username: realdb_username
     password: realdb_password
+  jpa:
+    hibernate:
+      ddl-auto: none

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,4 +24,4 @@ spring:
     password: realdb_password
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate


### PR DESCRIPTION
❗️ 이슈 번호
close #7 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
서비스 전체 엔티티를 생성했습니다.

기존에 스키마 ERD 참고하여 JPA 엔티티를 생성하였습니다.

### 엔티티
- 각 엔티티 id 네이밍은 `테이블명_ID` 로 설정하였습니다.
- `id`는 `auto_increment` 옵션을 사용합니다. `@GeneratedValue(strategy= GenerationType.IDENTITY)`
- 모든 엔티티에 `Builder` 생성자를 포함했습니다.
  - `id` 값은 `Builder` 에서 제외하였습니다.
- 외래키 제약 조건을 모두 없앴습니다.

### 기타
- enum을 어디에 둘까 고민하다가, 일단 specification 이라는 패키지에 넣어두었습니다. (추후 논의 필요)
- 다음 프로퍼티를 삭제하였습니다.
  - `spring.datasource.driver-class-name: com.mysql.jdbc.Driver`
  - 기존에 명시되어 있던 `com.mysql.jdbc.Driver`는 더이상 사용되지 않는다고 합니다.
  - 드라이버를 명시하지 않으면, 기본값으로 `com.mysql.cj.jdbc.Driver` 이 설정된다고 합니다.
<br><br>
[MySQL Workbench에서 생성한 테이블 ERD입니다.]
![스크린샷 2023-01-17 오후 1 10 07](https://user-images.githubusercontent.com/76773202/212808709-1eb737de-0055-46f5-ba6d-138f4e8ff7e0.png)

