### PR TITLE
feat: H2 memory DB 테스트 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -3,6 +3,7 @@ package com.nexters.phochak.domain;
 import javax.persistence.*;
 
 @Entity
+@Table(name = "`USER`")
 public class User {
 
     @Id

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL;
+  jpa:
+    generate-ddl: true
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console


### PR DESCRIPTION
❗️ 이슈 번호
close #12 

📝 구현 내용
이전에 회의 했던 대로, H2 데이터베이스로 테스트를 진행합니다.

### H2 예약어 issue
postgresSQL 등의 데이터베이스에서, 시스템의 유저 정보를 저장하기 위한 테이블로 USER 를 사용하고 있어서,
H2 데이터베이스의 기본 예약어에도 USER 가 생겼다고 합니다.

그래서 다음과 같이 백틱을 넣어서 해결했습니다.
 `@Table(name = "`USER`")`


💡 참고 자료
https://stackoverflow.com/questions/70797504/spring-data-jpa-h2-database-is-returning-ddl-error-during-table-creation