### PR TITLE
feat: OAuth 로그인 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,9 +18,20 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springCloudVersion', "2021.0.5")
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+	}
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/nexters/phochak/client/KakaoAccessTokenFeignClient.java
+++ b/src/main/java/com/nexters/phochak/client/KakaoAccessTokenFeignClient.java
@@ -1,0 +1,21 @@
+package com.nexters.phochak.client;
+
+import com.nexters.phochak.dto.KakaoAccessTokenResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "KakaoFeignClient",
+        url = "${kakao.api_url.token}")
+public interface KakaoAccessTokenFeignClient {
+
+    @PostMapping
+    KakaoAccessTokenResponseDto call(
+            @RequestHeader("Content-Type") String contentType,
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("redirect_uri") String redirectUri,
+            @RequestParam("code") String code
+    );
+}

--- a/src/main/java/com/nexters/phochak/client/KakaoInformationFeignClient.java
+++ b/src/main/java/com/nexters/phochak/client/KakaoInformationFeignClient.java
@@ -1,0 +1,17 @@
+package com.nexters.phochak.client;
+
+import com.nexters.phochak.dto.KakaoUserInformation;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "KakaoInformationFeignClient",
+        url = "${kakao.api_url.information}")
+public interface KakaoInformationFeignClient {
+
+    @GetMapping
+    KakaoUserInformation call(
+            @RequestHeader("Content-Type") String contentType,
+            @RequestHeader("Authorization") String accessToken
+    );
+}

--- a/src/main/java/com/nexters/phochak/config/OAuthConfig.java
+++ b/src/main/java/com/nexters/phochak/config/OAuthConfig.java
@@ -1,0 +1,22 @@
+package com.nexters.phochak.config;
+
+import com.nexters.phochak.service.OAuthService;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+public class OAuthConfig {
+
+    @Bean
+    public Map<OAuthProviderEnum, OAuthService> oAuthServiceEnumMap(List<OAuthService> oAuthServices) {
+        return new EnumMap<>(oAuthServices
+                .stream()
+                .collect(Collectors.toMap(OAuthService::getOAuthProvider, u -> u)));
+    }
+}

--- a/src/main/java/com/nexters/phochak/config/OpenFeignConfig.java
+++ b/src/main/java/com/nexters/phochak/config/OpenFeignConfig.java
@@ -1,0 +1,9 @@
+package com.nexters.phochak.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients("com.nexters.phochak.client")
+public class OpenFeignConfig {
+}

--- a/src/main/java/com/nexters/phochak/controller/LoginController.java
+++ b/src/main/java/com/nexters/phochak/controller/LoginController.java
@@ -1,0 +1,29 @@
+package com.nexters.phochak.controller;
+
+import com.nexters.phochak.dto.JoinRequestDto;
+import com.nexters.phochak.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/v1")
+@RestController
+public class LoginController {
+    private final UserService userService;
+
+    @GetMapping("login/{provider}")
+    public void login(@PathVariable String provider, @RequestParam String code) {
+        userService.login(provider, code);
+    }
+
+    @PostMapping("join/{provider}")
+    public void join(@PathVariable String provider, @RequestBody JoinRequestDto joinRequestDto) {
+        userService.join(provider, joinRequestDto);
+    }
+}

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -1,12 +1,9 @@
 package com.nexters.phochak.controller;
 
-import com.nexters.phochak.dto.JoinRequestDto;
 import com.nexters.phochak.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,16 +11,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/v1")
 @RestController
-public class LoginController {
+public class UserController {
     private final UserService userService;
 
     @GetMapping("login/{provider}")
     public void login(@PathVariable String provider, @RequestParam String code) {
         userService.login(provider, code);
-    }
-
-    @PostMapping("join/{provider}")
-    public void join(@PathVariable String provider, @RequestBody JoinRequestDto joinRequestDto) {
-        userService.join(provider, joinRequestDto);
     }
 }

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -1,12 +1,43 @@
 package com.nexters.phochak.domain;
 
-import javax.persistence.*;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import lombok.Builder;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
 @Entity
 public class User {
 
     @Id
-    @GeneratedValue(strategy= GenerationType.IDENTITY)
-    @Column(name="USER_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "USER_ID")
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private OAuthProviderEnum provider;
+
+    @Column(nullable = false, unique = true)
+    private String providerId;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    private String profileImgUrl;
+
+    public User() {
+    }
+
+    @Builder
+    public User(OAuthProviderEnum provider, String providerId, String nickname, String profileImgUrl) {
+        this.provider = provider;
+        this.providerId = providerId;
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+    }
 }

--- a/src/main/java/com/nexters/phochak/dto/JoinRequestDto.java
+++ b/src/main/java/com/nexters/phochak/dto/JoinRequestDto.java
@@ -1,0 +1,10 @@
+package com.nexters.phochak.dto;
+
+import lombok.Getter;
+
+@Getter
+public class JoinRequestDto {
+    private String providerId;
+    private String nickname;
+    private String profileImageUrl;
+}

--- a/src/main/java/com/nexters/phochak/dto/KakaoAccessTokenResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/KakaoAccessTokenResponseDto.java
@@ -1,0 +1,28 @@
+package com.nexters.phochak.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies.SnakeCaseStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@JsonNaming(SnakeCaseStrategy.class)
+@NoArgsConstructor
+@ToString
+@Getter
+public class KakaoAccessTokenResponseDto {
+
+    private String accessToken;
+    private String tokenType;
+    private String refreshToken;
+    private String expiresIn;
+    private String refreshTokenExpiresIn;
+
+    public KakaoAccessTokenResponseDto(String accessToken, String tokenType, String refreshToken, String expiresIn, String refreshTokenExpiresIn) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+        this.refreshToken = refreshToken;
+        this.expiresIn = expiresIn;
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/KakaoUserInformation.java
+++ b/src/main/java/com/nexters/phochak/dto/KakaoUserInformation.java
@@ -1,0 +1,47 @@
+package com.nexters.phochak.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class KakaoUserInformation extends OAuthUserInformation {
+    private static final OAuthProviderEnum provider = OAuthProviderEnum.KAKAO;
+
+    @JsonProperty(value = "id")
+    private String providerId;
+    @JsonProperty(value = "connected_at")
+    private String connectedAt;
+    private KakaoOAuthProperties properties;
+
+    @Override
+    public String getInitialNickname() {
+        return properties.getNickname();
+    }
+
+    @Override
+    public String getInitialProfileImage() {
+        return properties.thumbnailImage;
+    }
+
+    @Override
+    public OAuthProviderEnum getProvider() {
+        return provider;
+    }
+
+    @ToString
+    @Getter
+    static class KakaoOAuthProperties {
+        private String nickname;
+        @JsonProperty(value = "profile_image")
+        private String profileImage;
+        @JsonProperty(value = "thumbnail_image")
+        private String thumbnailImage;
+        // TODO: 아래 정보는 중복으로 받고있는데, 없앨 수 있는 방법 있는지 살펴봐야함
+        @JsonProperty(value = "kakao_account")
+        private String kakaoAccount;
+    }
+}
+

--- a/src/main/java/com/nexters/phochak/dto/OAuthUserInformation.java
+++ b/src/main/java/com/nexters/phochak/dto/OAuthUserInformation.java
@@ -1,0 +1,13 @@
+package com.nexters.phochak.dto;
+
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import lombok.Getter;
+
+@Getter
+public abstract class OAuthUserInformation {
+
+    private OAuthProviderEnum provider;
+    private String providerId;
+    private String initialNickname;
+    private String initialProfileImage;
+}

--- a/src/main/java/com/nexters/phochak/repository/UserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.nexters.phochak.repository;
+
+import com.nexters.phochak.domain.User;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByProviderAndProviderId(OAuthProviderEnum provider, String providerId);
+}

--- a/src/main/java/com/nexters/phochak/service/OAuthService.java
+++ b/src/main/java/com/nexters/phochak/service/OAuthService.java
@@ -1,0 +1,10 @@
+package com.nexters.phochak.service;
+
+import com.nexters.phochak.dto.OAuthUserInformation;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+
+public interface OAuthService {
+    OAuthProviderEnum getOAuthProvider();
+
+    OAuthUserInformation requestUserInformation(String authorizationCode);
+}

--- a/src/main/java/com/nexters/phochak/service/UserService.java
+++ b/src/main/java/com/nexters/phochak/service/UserService.java
@@ -1,0 +1,12 @@
+package com.nexters.phochak.service;
+
+public interface UserService {
+
+    /**
+     * OAuth 로그인을 진행한다.
+     *
+     * @param provider
+     * @param code
+     */
+    void login(String provider, String code);
+}

--- a/src/main/java/com/nexters/phochak/service/impl/KakaoOAuthServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/KakaoOAuthServiceImpl.java
@@ -1,0 +1,47 @@
+package com.nexters.phochak.service.impl;
+
+import com.nexters.phochak.client.KakaoAccessTokenFeignClient;
+import com.nexters.phochak.client.KakaoInformationFeignClient;
+import com.nexters.phochak.dto.KakaoAccessTokenResponseDto;
+import com.nexters.phochak.dto.OAuthUserInformation;
+import com.nexters.phochak.service.OAuthService;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoOAuthServiceImpl implements OAuthService {
+    private static final OAuthProviderEnum OAUTH_PROVIDER = OAuthProviderEnum.KAKAO;
+    private static final String TOKEN_PREFIX = "Bearer ";
+    private final KakaoAccessTokenFeignClient kakaoAccessTokenFeignClient;
+    private final KakaoInformationFeignClient kakaoInformationFeignClient;
+    @Value("${kakao.client_id}")
+    private String clientId;
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+
+    @Override
+    public OAuthProviderEnum getOAuthProvider() {
+        return OAUTH_PROVIDER;
+    }
+
+    @Override
+    public OAuthUserInformation requestUserInformation(String authorizationCode) {
+        KakaoAccessTokenResponseDto result = kakaoAccessTokenFeignClient.call(
+                "application/x-www-form-urlencoded",
+                "authorization_code",
+                clientId,
+                redirectUri,
+                authorizationCode
+        );
+
+        return kakaoInformationFeignClient.call(
+                "application/x-www-form-urlencoded;charset=utf-8",
+                TOKEN_PREFIX + result.getAccessToken()
+        );
+    }
+}

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -1,0 +1,58 @@
+package com.nexters.phochak.service.impl;
+
+import com.nexters.phochak.domain.User;
+import com.nexters.phochak.dto.JoinRequestDto;
+import com.nexters.phochak.dto.OAuthUserInformation;
+import com.nexters.phochak.repository.UserRepository;
+import com.nexters.phochak.service.OAuthService;
+import com.nexters.phochak.service.UserService;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+    private static final String NICKNAME_PREFIX = "여행자 ";
+
+    private final Map<OAuthProviderEnum, OAuthService> oAuthServiceMap;
+    private final UserRepository userRepository;
+
+    @Override
+    public void login(String provider, String code) {
+        OAuthProviderEnum providerEnum = OAuthProviderEnum.valueOf(provider.toUpperCase());
+        OAuthService oAuthService = oAuthServiceMap.get(providerEnum);
+        OAuthUserInformation userInformation = oAuthService.requestUserInformation(code);
+        if (userRepository.existsByProviderAndProviderId(userInformation.getProvider(), userInformation.getProviderId())) {
+            // TODO: 로그인 처리
+            log.info("UserServiceImpl|login(기존 회원): {}", userInformation);
+        } else {
+            log.info("UserServiceImpl|login(신규 회원): {}", userInformation);
+            String nickname = generateInitialNickname(userInformation);
+
+            User user = User.builder()
+                    .provider(userInformation.getProvider())
+                    .providerId(userInformation.getProviderId())
+                    .nickname(nickname)
+                    .profileImgUrl(userInformation.getInitialProfileImage())
+                    .build();
+
+            userRepository.save(user);
+
+            // TODO: 토큰 반환하여 로그인 처리
+        }
+    }
+
+    private String generateInitialNickname(OAuthUserInformation userInformation) {
+        // TODO: 초기 닉네임 설정 시 닉네임이 유일해야 하기 때문에 뒤에 난수나 고유한 채번로직이 들어가야 하는데 클라이언트와 협의 필요
+        if (StringUtils.hasText(userInformation.getInitialNickname())) {
+            return NICKNAME_PREFIX + userInformation.getInitialNickname() + userInformation.getProviderId().substring(0, 6);
+        }
+        return NICKNAME_PREFIX + userInformation.getProviderId().substring(0, 6);
+    }
+}

--- a/src/main/java/com/nexters/phochak/specification/OAuthProviderEnum.java
+++ b/src/main/java/com/nexters/phochak/specification/OAuthProviderEnum.java
@@ -1,0 +1,11 @@
+package com.nexters.phochak.specification;
+
+import lombok.Getter;
+
+@Getter
+public enum OAuthProviderEnum {
+    /**
+     * 지원하는 OAuth Provider 목록
+     */
+    APPLE, KAKAO
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  datasource:
+    driver-class-name: com.mysql.jdbc.Driver
+---
+spring:
   config:
     activate:
       on-profile: local
@@ -13,6 +17,18 @@ spring:
     properties:
       hibernate:
         format_sql: true
+# 카카오 OAUTH 관련 설정
+# TODO: 배포 환경별로 분리 필요, 운영에서는 secret key 적용하고 별도로 관리 필요 (애플 로그인이 어떻게 돼있는지 모름)
+kakao:
+  redirect_uri: http://localhost:8080/v1/login/kakao
+  client_id: 28e93f0db1f4c949133b2206f2ea7cd6
+  api_url:
+    token: https://kauth.kakao.com/oauth/token
+    information: https://kapi.kakao.com/v2/user/me
+
+logging:
+  level:
+    com.nexters.phochak: debug
 ---
 spring:
   config:


### PR DESCRIPTION
❗️ 이슈 번호
close #3 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
- `UserController - UserService - UserRepository` 를 통해 로그인 API 제공
  - OAuth에 필요한 기능은 OAuthService에게 의존 -> 로그인 요청 시 받는 `provider` 값으로 Provider 별로 구현체 제공
- OAuth 통신시에는 OpenFeign 활용 -> 코드가 좀 지저분하고 config 이나 최적화할 방법은 생각해봐야 합니다.
- `User` entity ERD대로 확정하고 소셜 로그인 통해서 회원가입 진행 -> DB에 insert 확인 -> 테스트 코드화 하면 좋을듯

### 추가로 구현해야 할 사항들 
- [ ] API 문서 작성용 Test
- [ ] 코드 최적화
- [ ] 닉네임 설정 시 생성 로직 협의
- [ ] Apple 로그인 flow 문의 
- [ ] application.yml에 있는 OAuth 관련 property 정리

🙇🏻‍♂️ 리뷰어에게 부탁합니다!
아직 약간 미완이긴 한거같은데 어디까지 진행됐는지 궁금하실 것 같아서 우선 PR올립니다!
draft 라고 생각하고 봐주시고 혹시 고치거나 개선했으면 하는 의견 있으시면 남겨주세요!
설에 급하게 PR 올리느라 내용 빠뜨린 게 있을수도 있어서 코드보면서 이해가 안되거나 하시면 슬랙에 남겨주세요 ㅠㅠ 감사합니다

💡 참고 자료
(없다면 지워도 됩니다!)
