### PR TITLE
feat: Apple login 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.29'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/nexters/phochak/client/AppleAuthKeyFeignClient.java
+++ b/src/main/java/com/nexters/phochak/client/AppleAuthKeyFeignClient.java
@@ -1,0 +1,11 @@
+package com.nexters.phochak.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "AppleAuthKeyFeignClient", url = "https://appleid.apple.com/auth/keys")
+public interface AppleAuthKeyFeignClient {
+
+    @GetMapping
+    String call();
+}

--- a/src/main/java/com/nexters/phochak/client/KakaoAccessTokenFeignClient.java
+++ b/src/main/java/com/nexters/phochak/client/KakaoAccessTokenFeignClient.java
@@ -6,8 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
-@FeignClient(name = "KakaoFeignClient",
-        url = "${kakao.api_url.token}")
+@FeignClient(name = "KakaoFeignClient", url = "${kakao.api_url.token}")
 public interface KakaoAccessTokenFeignClient {
 
     @PostMapping

--- a/src/main/java/com/nexters/phochak/client/KakaoInformationFeignClient.java
+++ b/src/main/java/com/nexters/phochak/client/KakaoInformationFeignClient.java
@@ -5,8 +5,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
-@FeignClient(name = "KakaoInformationFeignClient",
-        url = "${kakao.api_url.information}")
+@FeignClient(name = "KakaoInformationFeignClient", url = "${kakao.api_url.information}")
 public interface KakaoInformationFeignClient {
 
     @GetMapping

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -18,6 +18,7 @@ import javax.validation.constraints.Size;
 @Entity
 @Table(name = "`USER`")
 public class User extends BaseTime {
+    public static final int NICKNAME_MAX_SIZE = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,7 +31,7 @@ public class User extends BaseTime {
     @Column(nullable = false, unique = true)
     private String providerId;
 
-    @Size(min = 1, max = 20)
+    @Size(min = 1, max = NICKNAME_MAX_SIZE)
     @Column(nullable = false, unique = true)
     private String nickname;
 

--- a/src/main/java/com/nexters/phochak/dto/AppleUserInformation.java
+++ b/src/main/java/com/nexters/phochak/dto/AppleUserInformation.java
@@ -1,0 +1,23 @@
+package com.nexters.phochak.dto;
+
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Getter
+public class AppleUserInformation extends OAuthUserInformation {
+    private static final OAuthProviderEnum provider = OAuthProviderEnum.APPLE;
+    private String providerId;
+
+    @Override
+    public OAuthProviderEnum getProvider() {
+        return provider;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/KakaoUserInformation.java
+++ b/src/main/java/com/nexters/phochak/dto/KakaoUserInformation.java
@@ -23,11 +23,6 @@ public class KakaoUserInformation extends OAuthUserInformation {
     private KakaoOAuthProperties properties;
 
     @Override
-    public String getInitialNickname() {
-        return properties.getNickname();
-    }
-
-    @Override
     public String getInitialProfileImage() {
         return properties.thumbnailImage;
     }

--- a/src/main/java/com/nexters/phochak/dto/OAuthUserInformation.java
+++ b/src/main/java/com/nexters/phochak/dto/OAuthUserInformation.java
@@ -8,6 +8,5 @@ public abstract class OAuthUserInformation {
 
     private OAuthProviderEnum provider;
     private String providerId;
-    private String initialNickname;
     private String initialProfileImage;
 }

--- a/src/main/java/com/nexters/phochak/dto/jwt/Keys.java
+++ b/src/main/java/com/nexters/phochak/dto/jwt/Keys.java
@@ -1,0 +1,20 @@
+package com.nexters.phochak.dto.jwt;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class Keys {
+    private List<Key> keyList;
+
+    @Getter
+    public static class Key {
+        private String kty;
+        private String kid;
+        private String use;
+        private String alg;
+        private String n;
+        private String e;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/jwt/Keys.java
+++ b/src/main/java/com/nexters/phochak/dto/jwt/Keys.java
@@ -1,11 +1,13 @@
 package com.nexters.phochak.dto.jwt;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
 public class Keys {
+    @JsonProperty(value = "keys")
     private List<Key> keyList;
 
     @Getter

--- a/src/main/java/com/nexters/phochak/dto/response/LoginResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/LoginResponseDto.java
@@ -10,7 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class LoginResponseDto {
-    private String tokenType;
     private String accessToken;
     private String expiresIn;
     private String refreshToken;

--- a/src/main/java/com/nexters/phochak/exception/ResCode.java
+++ b/src/main/java/com/nexters/phochak/exception/ResCode.java
@@ -13,6 +13,7 @@ public enum ResCode {
     TOKEN_NOT_FOUND("P201", "토큰을 찾을 수 없습니다(로그인 되지 않은 사용자입니다.)"),
     INVALID_TOKEN("P202", "올바르지 않은 토큰입니다"),
     EXPIRED_TOKEN("P203", "만료된 토큰입니다"),
+    INVALID_APPLE_TOKEN("P204", "올바르지 않은 apple identifyToken입니다"),
 
     //P3xx: 유저 예외
     NOT_FOUND_USER("P300", "존재하지 않는 유저입니다"),

--- a/src/main/java/com/nexters/phochak/service/impl/AppleOAuthServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/AppleOAuthServiceImpl.java
@@ -1,0 +1,84 @@
+package com.nexters.phochak.service.impl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nexters.phochak.client.AppleAuthKeyFeignClient;
+import com.nexters.phochak.dto.AppleUserInformation;
+import com.nexters.phochak.dto.OAuthUserInformation;
+import com.nexters.phochak.dto.jwt.Keys;
+import com.nexters.phochak.exception.PhochakException;
+import com.nexters.phochak.exception.ResCode;
+import com.nexters.phochak.service.OAuthService;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AppleOAuthServiceImpl implements OAuthService {
+    private static final OAuthProviderEnum OAUTH_PROVIDER = OAuthProviderEnum.APPLE;
+    private final AppleAuthKeyFeignClient appleAuthKeyFeignClient;
+
+    @Override
+    public OAuthProviderEnum getOAuthProvider() {
+        return OAUTH_PROVIDER;
+    }
+
+    @Override
+    public OAuthUserInformation requestUserInformation(String authorizationCode) {
+        // jwt 복호화용 공개키 목록 가져오기
+        String publicKeys = appleAuthKeyFeignClient.call();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        Keys keys;
+        try {
+            keys = objectMapper.readValue(publicKeys, Keys.class);
+
+            SignedJWT signedJWT = SignedJWT.parse(authorizationCode);
+
+            boolean isVerified = isVerifiedToken(keys, signedJWT);
+
+            if (isVerified) {
+                JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+
+                return AppleUserInformation.builder()
+                        .providerId(jwtClaimsSet.getSubject())
+                        .build();
+            } else {
+                log.warn("AppleOAuthServiceImpl|requestUserInformation 서명 검증 실패 : {}", authorizationCode);
+                throw new PhochakException(ResCode.INVALID_APPLE_TOKEN);
+            }
+
+        } catch (JsonProcessingException | ParseException | JOSEException e) {
+            log.error("AppleOAuthServiceImpl|requestUserInformation Exception: {}", authorizationCode, e);
+            throw new PhochakException(ResCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private static boolean isVerifiedToken(Keys keys, SignedJWT signedJWT) throws ParseException, JsonProcessingException, JOSEException {
+        boolean isVerified = false;
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        for (Keys.Key key : keys.getKeyList()) {
+            RSAKey rsaKey = (RSAKey) JWK.parse(objectMapper.writeValueAsString(key));
+            RSAPublicKey publicKey = rsaKey.toRSAPublicKey();
+            RSASSAVerifier verifier = new RSASSAVerifier(publicKey);
+            if (signedJWT.verify(verifier)) {
+                isVerified = true;
+                break;
+            }
+        }
+        return isVerified;
+    }
+}

--- a/src/main/java/com/nexters/phochak/service/impl/JwtTokenServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/JwtTokenServiceImpl.java
@@ -55,10 +55,9 @@ public class JwtTokenServiceImpl implements JwtTokenService {
                 .build());
 
         return LoginResponseDto.builder()
-                .tokenType(TokenDto.TOKEN_TYPE)
-                .accessToken(accessToken.getTokenString())
+                .accessToken(createTokenStringForResponse(accessToken))
                 .expiresIn(accessToken.getExpiresIn())
-                .refreshToken(refreshToken.getTokenString())
+                .refreshToken(createTokenStringForResponse(refreshToken))
                 .refreshTokenExpiresIn(refreshToken.getExpiresIn())
                 .build();
     }
@@ -102,5 +101,9 @@ public class JwtTokenServiceImpl implements JwtTokenService {
                 .compact();
 
         return new TokenDto(jwt, String.valueOf(expireLength));
+    }
+
+    private static String createTokenStringForResponse(TokenDto accessToken) {
+        return TokenDto.TOKEN_TYPE + " " + accessToken.getTokenString();
     }
 }

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -12,17 +12,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @Slf4j
 @Transactional
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
-    private static final String NICKNAME_PREFIX = "여행자 ";
+    private static final String NICKNAME_PREFIX = "여행자#";
     private final Map<OAuthProviderEnum, OAuthService> oAuthServiceMap;
     private final UserRepository userRepository;
 
@@ -55,7 +55,7 @@ public class UserServiceImpl implements UserService {
 
         } else {
             log.info("UserServiceImpl|login(신규 회원): {}", userInformation);
-            String nickname = generateInitialNickname(userInformation);
+            String nickname = generateInitialNickname();
 
             User newUser = User.builder()
                     .provider(userInformation.getProvider())
@@ -69,11 +69,12 @@ public class UserServiceImpl implements UserService {
         return user;
     }
 
-    private static String generateInitialNickname(OAuthUserInformation userInformation) {
-        // TODO: 초기 닉네임 설정 시 닉네임이 유일해야 하기 때문에 뒤에 난수나 고유한 채번로직이 들어가야 하는데 클라이언트와 협의 필요
-        if (StringUtils.hasText(userInformation.getInitialNickname())) {
-            return NICKNAME_PREFIX + userInformation.getInitialNickname() + userInformation.getProviderId().substring(0, 6);
-        }
-        return NICKNAME_PREFIX + userInformation.getProviderId().substring(0, 6);
+    private static String generateInitialNickname() {
+        // 초기 닉네임 여행자#난수 6자로 결정
+        return NICKNAME_PREFIX + generateUUID();
+    }
+
+    private static String generateUUID() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, User.NICKNAME_MAX_SIZE - NICKNAME_PREFIX.length());
     }
 }

--- a/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
@@ -1,7 +1,6 @@
 package com.nexters.phochak.controller;
 
 import com.nexters.phochak.docs.RestDocs;
-import com.nexters.phochak.dto.TokenDto;
 import com.nexters.phochak.dto.response.LoginResponseDto;
 import com.nexters.phochak.service.UserService;
 import com.nexters.phochak.service.impl.JwtTokenServiceImpl;
@@ -53,11 +52,10 @@ class UserControllerTest extends RestDocs {
         String code = "testCode";
 
         LoginResponseDto response = LoginResponseDto.builder()
-                .tokenType(TokenDto.TOKEN_TYPE)
-                .accessToken("access token")
-                .expiresIn("access token lifetime")
-                .refreshToken("refresh token")
-                .refreshTokenExpiresIn("refresh token lifetime")
+                .accessToken("Bearer {jwt}")
+                .expiresIn("access token lifetime(ms)")
+                .refreshToken("Bearer {jwt}")
+                .refreshTokenExpiresIn("refresh token lifetime(ms)")
                 .build();
 
         when(jwtTokenService.createLoginResponse(any())).thenReturn(response);
@@ -72,7 +70,7 @@ class UserControllerTest extends RestDocs {
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
                                 pathParameters(
-                                        parameterWithName("provider").description("OAuth 서비스 이름(ex. kakao, apple, naver")
+                                        parameterWithName("provider").description("OAuth 서비스 이름(ex. kakao, apple, naver)")
                                 ),
                                 requestParameters(
                                         parameterWithName("code").description("Authorization code")
@@ -80,7 +78,6 @@ class UserControllerTest extends RestDocs {
                                 responseFields(
                                         fieldWithPath("resCode").type(JsonFieldType.STRING).description("응답 코드"),
                                         fieldWithPath("resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                        fieldWithPath("data.tokenType").type(JsonFieldType.STRING).description("토큰 타입"),
                                         fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("access token"),
                                         fieldWithPath("data.expiresIn").type(JsonFieldType.STRING).description("access token 유효기간(ms)"),
                                         fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("refresh token"),


### PR DESCRIPTION
❗️ 이슈 번호
close #29 


📝 구현 내용
- 애플 로그인 시 넘어오는 identifyToken을 통해 유저 정보 파악하여 가입 처리 후 로그인 처리까지 완료
  - 애플이 요구하는 검증 절차가 많은데.. 우선은 애플 공개키로 identifyToken 서명 검증만 처리되면 정상 요청으로 간주


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
애플 로그인에서 요구하는 인증절차가 개헬이라서... 일단 날치기로 했지만 작동은 잘되는거 같아 우선 PR 올립니다..ㅋㅋㅋ
시간나면 다른 절차들도 해보는걸로..


💡 참고 자료
https://developer111.tistory.com/58
