### PR TITLE
feat: Post 조회 시 hashtags 정보 추가

### DIFF
--- a/src/main/java/com/nexters/phochak/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/domain/Hashtag.java
@@ -1,9 +1,11 @@
 package com.nexters.phochak.domain;
 
 import lombok.Builder;
+import lombok.Getter;
 
 import javax.persistence.*;
 
+@Getter
 @Entity
 @Table(indexes = @Index(name = "idx_hashtag", columnList = "tag"))
 public class Hashtag {

--- a/src/main/java/com/nexters/phochak/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/domain/Post.java
@@ -26,7 +26,6 @@ import java.util.List;
 @Getter
 @Entity
 public class Post extends BaseTime {
-
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     @Column(name="POST_ID")
@@ -50,6 +49,9 @@ public class Post extends BaseTime {
 
     @OneToMany(mappedBy = "post")
     private List<Likes> likes;
+
+    @OneToMany(mappedBy = "post")
+    private List<Hashtag> hashtags;
 
     public Post() {
     }

--- a/src/main/java/com/nexters/phochak/dto/response/PostPageResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/PostPageResponseDto.java
@@ -1,5 +1,6 @@
 package com.nexters.phochak.dto.response;
 
+import com.nexters.phochak.domain.Hashtag;
 import com.nexters.phochak.domain.Post;
 import com.nexters.phochak.domain.Shorts;
 import com.nexters.phochak.domain.User;
@@ -9,6 +10,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -16,6 +20,7 @@ public class PostPageResponseDto {
     private long id;
     private User user;
     private Shorts shorts;
+    private List<String> hashtags;
     private long view;
     private PostCategoryEnum category;
     private long like;
@@ -26,10 +31,25 @@ public class PostPageResponseDto {
                 .id(post.getId())
                 .user(post.getUser())
                 .shorts(post.getShorts())
+                .hashtags(post.getHashtags().stream().map(Hashtag::getTag).collect(Collectors.toList()))
                 .view(post.getView())
                 .category(post.getPostCategory())
                 .like(post.getLikes().size())
                 .isLiked(post.getLikes().stream().anyMatch(likes -> likes.hasLikesByUser(userId)))
                 .build();
+    }
+
+    @Getter
+    private static class HashTagsDto {
+        private final List<String> tags;
+
+        private HashTagsDto(List<String> tags) {
+            this.tags = tags;
+        }
+
+        public static HashTagsDto from(List<Hashtag> hashtags) {
+            List<String> tags = hashtags.stream().map(Hashtag::getTag).collect(Collectors.toList());
+            return new HashTagsDto(tags);
+        }
     }
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -37,6 +37,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .join(post.user).fetchJoin()
                 .join(post.shorts).fetchJoin()
                 .join(post.likes).fetchJoin()
+                .join(post.hashtags)
                 .where(filterByCursor(customCursor.getSortOption(), customCursor))
                 .limit(customCursor.getPageSize())
                 .orderBy(orderByPostSortOption(customCursor.getSortOption()))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
       hibernate:
         format_sql: true
         show_sql: true
+        default_batch_fetch_size: 1000
 # 카카오 OAUTH 관련 설정
 # TODO: 배포 환경별로 분리 필요, 운영에서는 secret key 적용하고 별도로 관리 필요 (애플 로그인이 어떻게 돼있는지 모름)
 kakao:

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -153,7 +153,7 @@ class PostControllerTest extends RestDocs {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(3)
                 .sortOption(PostSortOption.LIKE)
-                .lastId(3L)
+                .lastId(20L)
                 .sortValue(75)
                 .build();
 

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -71,6 +71,9 @@ class PostControllerTest extends RestDocs {
                 .shortsUrl("shorts url")
                 .build();
 
+        List<String> hashtags1 = List.of("해시태그1", "해시태그2");
+        List<String> hashtags2 = List.of("해시태그2", "해시태그3");
+
         post1 = PostPageResponseDto.builder()
                 .id(5L)
                 .user(user)
@@ -79,6 +82,7 @@ class PostControllerTest extends RestDocs {
                 .category(PostCategoryEnum.RESTAURANT)
                 .like(10L)
                 .isLiked(Boolean.TRUE)
+                .hashtags(hashtags1)
                 .build();
 
         post2 = PostPageResponseDto.builder()
@@ -89,6 +93,7 @@ class PostControllerTest extends RestDocs {
                 .category(PostCategoryEnum.TOUR)
                 .like(21L)
                 .isLiked(Boolean.FALSE)
+                .hashtags(hashtags2)
                 .build();
     }
 
@@ -133,6 +138,7 @@ class PostControllerTest extends RestDocs {
                                 fieldWithPath("data[].shorts.id").type(JsonFieldType.NUMBER).description("영상 id"),
                                 fieldWithPath("data[].shorts.thumbnailUrl").type(JsonFieldType.STRING).description("영상 썸네일 이미지 링크"),
                                 fieldWithPath("data[].shorts.shortsUrl").type(JsonFieldType.STRING).description("영상 링크"),
+                                fieldWithPath("data[].hashtags").type(JsonFieldType.ARRAY).description("해시태그 목록"),
                                 fieldWithPath("data[].view").type(JsonFieldType.NUMBER).description("조회수"),
                                 fieldWithPath("data[].category").type(JsonFieldType.STRING).description("게시글 카테고리"),
                                 fieldWithPath("data[].like").type(JsonFieldType.NUMBER).description("좋아요 수"),
@@ -151,6 +157,8 @@ class PostControllerTest extends RestDocs {
                 .sortValue(75)
                 .build();
 
+        List<String> hashtags = List.of("해시태그4", "해시태그5");
+
         PostPageResponseDto post3 = PostPageResponseDto.builder()
                 .id(17L)
                 .user(user)
@@ -159,6 +167,7 @@ class PostControllerTest extends RestDocs {
                 .category(PostCategoryEnum.TOUR)
                 .like(75L)
                 .isLiked(Boolean.TRUE)
+                .hashtags(hashtags)
                 .build();
 
         List<PostPageResponseDto> result = List.of(post3, post2, post1);
@@ -199,6 +208,7 @@ class PostControllerTest extends RestDocs {
                                 fieldWithPath("data[].shorts.id").type(JsonFieldType.NUMBER).description("영상 id"),
                                 fieldWithPath("data[].shorts.thumbnailUrl").type(JsonFieldType.STRING).description("영상 썸네일 이미지 링크"),
                                 fieldWithPath("data[].shorts.shortsUrl").type(JsonFieldType.STRING).description("영상 링크"),
+                                fieldWithPath("data[].hashtags").type(JsonFieldType.ARRAY).description("해시태그 목록"),
                                 fieldWithPath("data[].view").type(JsonFieldType.NUMBER).description("조회수"),
                                 fieldWithPath("data[].category").type(JsonFieldType.STRING).description("게시글 카테고리"),
                                 fieldWithPath("data[].like").type(JsonFieldType.NUMBER).description("좋아요 수"),
@@ -217,6 +227,8 @@ class PostControllerTest extends RestDocs {
                 .sortValue(100)
                 .build();
 
+        List<String> hashtags = List.of("해시태그4", "해시태그5");
+
         PostPageResponseDto post3 = PostPageResponseDto.builder()
                 .id(20L)
                 .user(user)
@@ -225,6 +237,7 @@ class PostControllerTest extends RestDocs {
                 .category(PostCategoryEnum.RESTAURANT)
                 .like(28)
                 .isLiked(Boolean.TRUE)
+                .hashtags(hashtags)
                 .build();
 
         List<PostPageResponseDto> result = List.of(post3, post2, post1);
@@ -265,6 +278,7 @@ class PostControllerTest extends RestDocs {
                                 fieldWithPath("data[].shorts.id").type(JsonFieldType.NUMBER).description("영상 id"),
                                 fieldWithPath("data[].shorts.thumbnailUrl").type(JsonFieldType.STRING).description("영상 썸네일 이미지 링크"),
                                 fieldWithPath("data[].shorts.shortsUrl").type(JsonFieldType.STRING).description("영상 링크"),
+                                fieldWithPath("data[].hashtags").type(JsonFieldType.ARRAY).description("해시태그 목록"),
                                 fieldWithPath("data[].view").type(JsonFieldType.NUMBER).description("조회수"),
                                 fieldWithPath("data[].category").type(JsonFieldType.STRING).description("게시글 카테고리"),
                                 fieldWithPath("data[].like").type(JsonFieldType.NUMBER).description("좋아요 수"),


### PR DESCRIPTION
❗️ 이슈 번호
close #42 


📝 구현 내용
- 포스트 목록 조회 시 해시태그 목록 추가



🙇🏻‍♂️ 리뷰어에게 부탁합니다!
쉬려고 했지만... 금방 끝날거 같아 후딱 작업했습니다...!!
얼른 1순위 기능들을 끝내야 하는데 갈길이 머네요...


💡 참고 자료
(없다면 지워도 됩니다!)
