### PR TITLE
docs: 서버 응답코드 문서화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 # Generated files
 .idea/**/contentModel.xml
 **/resources/static/docs
+src/docs/asciidoc/rescode.adoc
 
 # Sensitive or high-churn files
 .idea/**/dataSources/

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,6 +11,8 @@ endif::[]
 
 = Phochak API 문서
 
+include::rescode.adoc[]
+
 include::login.adoc[]
 
 include::post.adoc[]

--- a/src/docs/asciidoc/likes.adoc
+++ b/src/docs/asciidoc/likes.adoc
@@ -1,9 +1,15 @@
 == 포착하기 APIs
-
-=== 포착하기 / 포착 취소하기
 포착하기 / 포착취소하기 기능을 제공한다.
 
-==== 포착하기 요청
+=== 포착하기 요청
+
+==== 발생 가능 서비스 예외 코드
+"P400", "존재하지 않는 게시글입니다"
+
+"P410", "이미 포착된 게시글입니다"
+
+
+==== 요청
 HTTP Example
 
 include::{snippets}/post/{postId}/likes/post/http-request.adoc[]
@@ -26,9 +32,15 @@ Response Parameters
 
 include::{snippets}/post/{postId}/likes/post/response-fields.adoc[]
 
-==== 포착 취소하기 요청
+=== 포착 취소하기 요청
+
+==== 발생 가능 서비스 예외 코드
+"P400", "존재하지 않는 게시글입니다"
+"P411", "포착 하지 않은 게시글입니다"
+
 HTTP Example
 
+==== 요청
 include::{snippets}/post/{postId}/likes/delete/http-request.adoc[]
 
 Path Parameters

--- a/src/docs/asciidoc/login.adoc
+++ b/src/docs/asciidoc/login.adoc
@@ -3,6 +3,14 @@
 === 로그인
 OAuth 2.0을 활용한 로그인 (및 회원가입) 을 진행한다.
 
+==== 발생 가능 서비스 예외 코드
+"P204", "올바르지 않은 apple identifyToken입니다"
+
+"P205", "지원하지 않는 provider입니다"
+
+"P300", "존재하지 않는 유저입니다"
+
+
 ==== 요청
 HTTP Example
 
@@ -25,3 +33,4 @@ include::{snippets}/user/login/http-response.adoc[]
 Response Parameters
 
 include::{snippets}/user/login/response-fields.adoc[]
+

--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -3,6 +3,14 @@
 === 게시글 불러오기
 조회 기준(포착순, 최신순, 조회순)에 따라 원하는 size만큼 게시글을 불러옵니다.
 
+==== 발생 가능 서비스 예외 코드
+"P412", "최신순이 아닌 경우 정렬기준의 값은 필수입니다"
+
+"P413", "지원하지 않는 정렬기준입니다"
+
+"P414", "정렬 기준이 존재하지 않습니다"
+
+
 ==== 첫 페이지 요청
 HTTP Example
 
@@ -75,6 +83,10 @@ include::{snippets}/post/list/after/response-fields.adoc[]
 === Presigned URL 발급
 S3 버킷에 미디어를 업로드 하기 위해, Presigned URL, upload key를 발급한다.
 
+==== 발생 가능 서비스 예외 코드
+x
+
+==== 요청
 HTTP Example
 
 include::{snippets}/post/upload-key/GET/http-request.adoc[]
@@ -101,6 +113,10 @@ include::{snippets}/post/upload-key/GET/response-fields.adoc[]
 === 포스트 업로드
 포스트 업로드 기능을 제공한다
 
+==== 발생 가능 서비스 예외 코드
+"P401", "해시태그에는 공백이 들어갈 수 없습니다."
+
+==== 요청
 HTTP Example
 
 include::{snippets}/post/POST/http-request.adoc[]

--- a/src/main/java/com/nexters/phochak/exception/ResCode.java
+++ b/src/main/java/com/nexters/phochak/exception/ResCode.java
@@ -9,24 +9,26 @@ public enum ResCode {
     INTERNAL_SERVER_ERROR("P100", "서버 에러 발생"),
 
     //P2xx: 인증 예외
-    INVALID_INPUT("P200", "올바르지 않은 입력값입니다"),
-    TOKEN_NOT_FOUND("P201", "토큰을 찾을 수 없습니다(로그인 되지 않은 사용자입니다.)"),
+    INVALID_INPUT("P200", "요청 값이 올바르지 않습니다"),
+    TOKEN_NOT_FOUND("P201", "토큰을 찾을 수 없습니다(로그인 되지 않은 사용자입니다)"),
     INVALID_TOKEN("P202", "올바르지 않은 토큰입니다"),
     EXPIRED_TOKEN("P203", "만료된 토큰입니다"),
     INVALID_APPLE_TOKEN("P204", "올바르지 않은 apple identifyToken입니다"),
+    NOT_SUPPORTED_PROVIDER("P205", "지원하지 않는 provider입니다"),
 
     //P3xx: 유저 예외
     NOT_FOUND_USER("P300", "존재하지 않는 유저입니다"),
 
     //P4xx: 게시글 예외
     NOT_FOUND_POST("P400", "존재하지 않는 게시글입니다"),
+    SPACE_IN_HASHTAG("P401", "해시태그에는 공백이 들어갈 수 없습니다."),
     ALREADY_PHOCHAKED("P410", "이미 포착된 게시글입니다"),
     NOT_PHOCHAKED("P411", "포착 하지 않은 게시글입니다"),
     NOT_FOUND_SORT_VALUE("P412", "최신순이 아닌 경우 정렬기준의 값은 필수입니다"),
     NOT_SUPPORTED_SORT_OPTION("P413", "지원하지 않는 정렬기준입니다"),
     NOT_FOUND_SORT_OPTION("P414", "정렬 기준이 존재하지 않습니다"),
-    NOT_SUPPORT_VIDEO_EXTENSION("P450", "지원하지 않는 영상 확장자"),
-    INVALID_VIDEO_FORMAT("P451", "잘못되거나 알 수 없는 영상 형식");
+
+    INVALID_VIDEO_FORMAT("P450", "지원하지 않는 비디오 확장자입니다.");
 
     //P5xx: 파일 예외
 

--- a/src/main/java/com/nexters/phochak/repository/impl/MediaFileLocalRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/MediaFileLocalRepository.java
@@ -24,7 +24,7 @@ public class MediaFileLocalRepository implements MediaFileRepository {
         try {
             shorts.transferTo(filePath);
         } catch(IllegalStateException e) {
-            throw new PhochakException(ResCode.INVALID_VIDEO_FORMAT, "올바르지 않은 파일");
+            throw new PhochakException(ResCode.INVALID_VIDEO_FORMAT);
         } catch(IOException e) {
             throw new PhochakException(ResCode.INTERNAL_SERVER_ERROR, "영상 파일 처리 실패");
         }

--- a/src/main/java/com/nexters/phochak/service/impl/HashtagServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/HashtagServiceImpl.java
@@ -37,7 +37,7 @@ public class HashtagServiceImpl implements HashtagService {
     private void validateHashtag(List<String> stringHashtagList) {
         for(String tag : stringHashtagList) {
             if(tag.contains(" ")) {
-                throw new PhochakException(ResCode.INVALID_INPUT, "해시태그에 공백이 존재합니다.");
+                throw new PhochakException(ResCode.SPACE_IN_HASHTAG, "해시태그에 공백이 존재합니다.");
             }
         }
     }

--- a/src/main/java/com/nexters/phochak/specification/OAuthProviderEnum.java
+++ b/src/main/java/com/nexters/phochak/specification/OAuthProviderEnum.java
@@ -24,6 +24,6 @@ public enum OAuthProviderEnum {
             }
         }
 
-        throw new PhochakException(ResCode.INVALID_INPUT, "지원하지 않는 provider code입니다.");
+        throw new PhochakException(ResCode.NOT_SUPPORTED_PROVIDER);
     }
 }

--- a/src/test/java/com/nexters/phochak/docs/ResCodeDocs.java
+++ b/src/test/java/com/nexters/phochak/docs/ResCodeDocs.java
@@ -17,9 +17,9 @@ public class ResCodeDocs extends RestDocs {
 
         StringBuilder builder = new StringBuilder();
 
-        builder.append("== 서비스 응답 코드\n");
-        builder.append("서비스 응답 코드입니다.\n");
-        builder.append("응답 메시지는 디버깅 편의를 위해 조금씩 변경될 수 있습니다.\n");
+        builder.append("== 서비스 응답 코드\n\n");
+        builder.append("서비스 응답 코드입니다.\n\n");
+        builder.append("응답 메시지는 디버깅 편의를 위해 조금씩 변경될 수 있습니다.\n\n");
 
         builder.append("|===\n");
         builder.append("|코드(resCode) |메시지(resMessage) \n\n");
@@ -30,6 +30,14 @@ public class ResCodeDocs extends RestDocs {
                 });
 
         builder.append("|===\n");
+
+        builder.append("=== 서비스 전체에서 발생 가능한 공통 코드\n");
+        builder.append("\"P000\", \"정상 처리\"\n\n");
+        builder.append("\"P100\", \"서버 에러 발생 (HTTP 200번 응답. 서버에서)\"\n\n");
+        builder.append("\"P200\", \"요청 값이 올바르지 않습니다\" - param, body 값 누락 등\n\n");
+        builder.append("\"P201\", \"토큰을 찾을 수 없습니다(로그인 되지 않은 사용자입니다)\"\n\n");
+        builder.append("\"P202\", \"올바르지 않은 토큰입니다\"\n\n");
+        builder.append("\"P203\", \"만료된 토큰입니다\" - 재발급 필요\n\n");
 
         try (FileOutputStream fos = new FileOutputStream("src/docs/asciidoc/rescode.adoc")) {
             fos.write(builder.toString().getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/nexters/phochak/docs/ResCodeDocs.java
+++ b/src/test/java/com/nexters/phochak/docs/ResCodeDocs.java
@@ -1,0 +1,38 @@
+package com.nexters.phochak.docs;
+
+import com.nexters.phochak.docs.RestDocs;
+import com.nexters.phochak.exception.ResCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class ResCodeDocs extends RestDocs {
+
+    @Test
+    @DisplayName("ResCode 출력")
+    void resCode() throws Exception {
+
+        StringBuilder builder = new StringBuilder();
+
+        builder.append("== 서비스 응답 코드\n");
+        builder.append("서비스 응답 코드입니다.\n");
+        builder.append("응답 메시지는 디버깅 편의를 위해 조금씩 변경될 수 있습니다.\n");
+
+        builder.append("|===\n");
+        builder.append("|코드(resCode) |메시지(resMessage) \n\n");
+
+        Arrays.stream(ResCode.values())
+                .forEach(e -> {
+                    builder.append(String.format("|%s |%s \n", e.getCode(), e.getMessage()));
+                });
+
+        builder.append("|===\n");
+
+        try (FileOutputStream fos = new FileOutputStream("src/docs/asciidoc/rescode.adoc")) {
+            fos.write(builder.toString().getBytes(StandardCharsets.UTF_8));
+        }
+    }
+}

--- a/src/test/java/com/nexters/phochak/service/impl/HashtagServiceImplTest.java
+++ b/src/test/java/com/nexters/phochak/service/impl/HashtagServiceImplTest.java
@@ -56,7 +56,7 @@ class HashtagServiceImplTest {
     }
 
     @Test
-    @DisplayName("해시태그에 공백이 있으면 INVALID_INPUT 예외가 발생한다")
+    @DisplayName("해시태그에 공백이 있으면 SPACE_IN_HASHTAG 예외가 발생한다")
     void createHashtagWithSpace_invalidInput() {
         //given
         List<String> stringHashList = List.of("해시태 그1", " 해시태그2", "해시태그 3");
@@ -65,7 +65,7 @@ class HashtagServiceImplTest {
         //when, then
         assertThatThrownBy(() -> hashtagService.saveHashtagsByString(stringHashList, post))
                 .isInstanceOf(PhochakException.class)
-                .hasMessage(ResCode.INVALID_INPUT.getMessage());
+                .hasMessage(ResCode.SPACE_IN_HASHTAG.getMessage());
     }
 
 }


### PR DESCRIPTION
❗️ 이슈 번호
close #31 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
응답코드 Spring Rest Docs에 문서화 진행했습니다.

![스크린샷 2023-02-10 오전 11 49 09](https://user-images.githubusercontent.com/76773202/217987991-cad9287f-1a56-4278-827f-b6bf6019961d.png)


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

https://velog.io/@backtony/Spring-REST-Docs-%EC%A0%81%EC%9A%A9-%EB%B0%8F-%EC%B5%9C%EC%A0%81%ED%99%94-%ED%95%98%EA%B8%B0#enum-%EC%BD%94%EB%93%9C-%EB%AC%B8%EC%84%9C%ED%99%94
원래 여기 Enum 코드 문서화 보고 따라하려고 했는데, 삽질에 실패하였습니다. 🥲

💡 참고 자료
(없다면 지워도 됩니다!)
