### PR TITLE
feat: 유저 정보 조회용 API 구현

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -34,6 +34,48 @@ Response Parameters
 
 include::{snippets}/user/login/response-fields.adoc[]
 
+=== 회원정보 가져오기
+현재 로그인된 유저의 정보를 가져온다.
+
+==== 요청
+HTTP Example
+
+include::{snippets}/user/http-request.adoc[]
+
+Request Headers
+
+include::{snippets}/user/request-headers.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/user/http-response.adoc[]
+
+Response Parameters
+
+include::{snippets}/user/response-fields.adoc[]
+
+**회원정보 API 응답코드**
+[cols="2,10,7"]
+|===
+|응답코드
+|응답메시지
+|설명
+
+|P000
+|정상 처리
+|조회 성공
+
+|P201
+|토큰을 찾을 수 없습니다(로그인 되지 않은 사용자입니다)
+|로그인 되지 않았거나 토큰 누락
+
+|P300
+|존재하지 않는 유저입니다
+|존재하지 않는 유저를 조회
+|===
+
 === 닉네임 중복체크
 변경하려는 닉네임의 중복 여부를 체크한다.
 
@@ -63,6 +105,10 @@ include::{snippets}/user/check/nickname/response-fields.adoc[]
 HTTP Example
 
 include::{snippets}/user/modify/nickname/http-request.adoc[]
+
+Request Headers
+
+include::{snippets}/user/request-headers.adoc[]
 
 Request Parameters
 
@@ -100,3 +146,4 @@ include::{snippets}/user/modify/nickname/response-fields.adoc[]
 |P301
 |닉네임이 중복되었습니다
 |저장하려는 시점에 닉네임 중복 발생, 수정하여 재시도 필요
+|===

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -1,11 +1,13 @@
 package com.nexters.phochak.controller;
 
+import com.nexters.phochak.auth.UserContext;
 import com.nexters.phochak.auth.annotation.Auth;
 import com.nexters.phochak.dto.request.LoginRequestDto;
 import com.nexters.phochak.dto.request.NicknameModifyRequestDto;
 import com.nexters.phochak.dto.response.CommonResponse;
 import com.nexters.phochak.dto.response.LoginResponseDto;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
+import com.nexters.phochak.dto.response.UserInfoResponseDto;
 import com.nexters.phochak.exception.PhochakException;
 import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.service.JwtTokenService;
@@ -59,5 +61,12 @@ public class UserController {
             throw new PhochakException(ResCode.DUPLICATED_NICKNAME);
         }
         return new CommonResponse<>();
+    }
+
+    @Auth
+    @GetMapping
+    public CommonResponse<UserInfoResponseDto> getInfo() {
+        Long userId = UserContext.CONTEXT.get();
+        return new CommonResponse<>(userService.getInfo(userId));
     }
 }

--- a/src/main/java/com/nexters/phochak/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,24 @@
+package com.nexters.phochak.dto.response;
+
+import com.nexters.phochak.domain.User;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class UserInfoResponseDto {
+    private long id;
+    private String nickname;
+    private String profileImgUrl;
+
+    public static UserInfoResponseDto of(User user) {
+        return UserInfoResponseDto.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .profileImgUrl(user.getProfileImgUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/nexters/phochak/service/UserService.java
+++ b/src/main/java/com/nexters/phochak/service/UserService.java
@@ -1,6 +1,7 @@
 package com.nexters.phochak.service;
 
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
+import com.nexters.phochak.dto.response.UserInfoResponseDto;
 
 public interface UserService {
 
@@ -25,5 +26,16 @@ public interface UserService {
      */
     UserCheckResponseDto checkNicknameIsDuplicated(String nickname);
 
+    /**
+     * 원하는 닉네임으로 닉네임을 변경한다.
+     * @param nickname
+     */
     void modifyNickname(String nickname);
+
+    /**
+     * 해당 유저의 정보를 조회한다.
+     * @param userId
+     * @return
+     */
+    UserInfoResponseDto getInfo(Long userId);
 }

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import com.nexters.phochak.auth.UserContext;
 import com.nexters.phochak.domain.User;
 import com.nexters.phochak.dto.OAuthUserInformation;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
+import com.nexters.phochak.dto.response.UserInfoResponseDto;
 import com.nexters.phochak.exception.PhochakException;
 import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.repository.UserRepository;
@@ -65,6 +66,13 @@ public class UserServiceImpl implements UserService {
         }
 
         user.modifyNickname(nickname);
+    }
+
+    @Override
+    public UserInfoResponseDto getInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
+        return UserInfoResponseDto.of(user);
     }
 
     private boolean isDuplicatedNickname(String nickname) {

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -115,7 +115,7 @@ class PostControllerTest extends RestDocs {
                                 .get("/v1/post/list")
                                 .param("sortOption", customCursor.getSortOption().name())
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
-                                .header(AUTHORIZATION_HEADER, "testToken"))
+                                .header(AUTHORIZATION_HEADER, "access token"))
                 .andExpect(status().isOk())
                 .andDo(document("post/list/initial",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
@@ -183,7 +183,7 @@ class PostControllerTest extends RestDocs {
                                 .param("lastId", String.valueOf(customCursor.getLastId()))
                                 .param("sortOption", customCursor.getSortOption().name())
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
-                                .header(AUTHORIZATION_HEADER, "testToken")
+                                .header(AUTHORIZATION_HEADER, "access token")
                 )
                 .andExpect(status().isOk())
                 .andDo(document("post/list/after",
@@ -254,7 +254,7 @@ class PostControllerTest extends RestDocs {
                                 .param("lastId", String.valueOf(customCursor.getLastId()))
                                 .param("sortOption", customCursor.getSortOption().name())
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
-                                .header(AUTHORIZATION_HEADER, "testToken")
+                                .header(AUTHORIZATION_HEADER, "access token")
                 )
                 .andExpect(status().isOk())
                 .andDo(document("post/list/last",


### PR DESCRIPTION
❗️ 이슈 번호
close #70 


📝 구현 내용
- 메인이나 마이페이지 등에서 유저 정보 출력용으로 조회 API 생성



🙇🏻‍♂️ 리뷰어에게 부탁합니다!
나중에 캐싱 등을 활용하면 개선해볼 수 있겠네요 ㅎㅎ


💡 참고 자료
(없다면 지워도 됩니다!)
