### PR TITLE
feat: 유저페이지 정보 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -34,13 +34,21 @@ Response Parameters
 
 include::{snippets}/user/login/response-fields.adoc[]
 
-=== 회원정보 가져오기
+=== 유저페이지 유저 정보 조회
 현재 로그인된 유저의 정보를 가져온다.
 
 ==== 요청
 HTTP Example
 
+다른 유저의 유저페이지 조회 예시
 include::{snippets}/user/http-request.adoc[]
+
+본인 유저페이지 조회 예시
+include::{snippets}/user/me/http-request.adoc[]
+
+Path Parameters
+
+include::{snippets}/user/path-parameters.adoc[]
 
 Request Headers
 

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -64,8 +64,8 @@ public class UserController {
     }
 
     @Auth
-    @GetMapping("/{userId}")
-    public CommonResponse<UserInfoResponseDto> getInfo(@PathVariable(value = "userId") Long pageOwnerId) {
+    @GetMapping({"/{userId}", "/"})
+    public CommonResponse<UserInfoResponseDto> getInfo(@PathVariable(value = "userId", required = false) Long pageOwnerId) {
         Long userId = UserContext.CONTEXT.get();
         return new CommonResponse<>(userService.getInfo(pageOwnerId, userId));
     }

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -64,9 +64,9 @@ public class UserController {
     }
 
     @Auth
-    @GetMapping
-    public CommonResponse<UserInfoResponseDto> getInfo() {
+    @GetMapping("/{userId}")
+    public CommonResponse<UserInfoResponseDto> getInfo(@PathVariable(value = "userId") Long pageOwnerId) {
         Long userId = UserContext.CONTEXT.get();
-        return new CommonResponse<>(userService.getInfo(userId));
+        return new CommonResponse<>(userService.getInfo(pageOwnerId, userId));
     }
 }

--- a/src/main/java/com/nexters/phochak/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/UserInfoResponseDto.java
@@ -13,9 +13,11 @@ public class UserInfoResponseDto {
     private long id;
     private String nickname;
     private String profileImgUrl;
+    private Boolean isMyPage;
 
-    public static UserInfoResponseDto of(User user) {
+    public static UserInfoResponseDto of(User user, Boolean isMyPage) {
         return UserInfoResponseDto.builder()
+                .isMyPage(isMyPage)
                 .id(user.getId())
                 .nickname(user.getNickname())
                 .profileImgUrl(user.getProfileImgUrl())

--- a/src/main/java/com/nexters/phochak/service/UserService.java
+++ b/src/main/java/com/nexters/phochak/service/UserService.java
@@ -37,5 +37,5 @@ public interface UserService {
      * @param userId
      * @return
      */
-    UserInfoResponseDto getInfo(Long userId);
+    UserInfoResponseDto getInfo(Long pageOwnerId, Long userId);
 }

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -69,10 +69,14 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public UserInfoResponseDto getInfo(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
-        return UserInfoResponseDto.of(user);
+    public UserInfoResponseDto getInfo(Long pageOwnerId, Long userId) {
+        User pageOwner;
+        if (pageOwnerId == null) {
+            pageOwner = userRepository.findById(userId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
+        } else {
+            pageOwner = userRepository.findById(pageOwnerId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
+        }
+        return UserInfoResponseDto.of(pageOwner, pageOwner.getId().equals(userId));
     }
 
     private boolean isDuplicatedNickname(String nickname) {

--- a/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
@@ -165,19 +165,20 @@ class UserControllerTest extends RestDocs {
     }
 
     @Test
-    @DisplayName("유저 API - 유저 정보 조회하기")
-    void getInfo() throws Exception {
+    @DisplayName("유저 API - 다른 유저 페이지 정보 조회하기")
+    void getInfoOtherUserPage() throws Exception {
         UserInfoResponseDto response = UserInfoResponseDto.builder()
+                .isMyPage(false)
                 .id(1L)
                 .nickname("nickname")
                 .profileImgUrl("profile image url")
                 .build();
 
-        given(userService.getInfo(any())).willReturn(response);
+        given(userService.getInfo(any(),any())).willReturn(response);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders
-                                .get("/v1/user")
+                                .get("/v1/user/{userId}", 10)
                                 .header(AUTHORIZATION_HEADER, "access token"))
                 .andExpect(status().isOk())
                 .andDo(document("user",
@@ -187,9 +188,48 @@ class UserControllerTest extends RestDocs {
                                 headerWithName(AUTHORIZATION_HEADER)
                                         .description("(필수) JWT Access Token")
                         ),
+                        pathParameters(
+                                parameterWithName("userId").description("(선택) 조회하려는 유저의 id. 만약 본인의 유저 페이지를 조회 한다면 빈 값 사용")
+                        ),
                         responseFields(
                                 fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
                                 fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.isMyPage").type(JsonFieldType.BOOLEAN).description("접속자가 해당 페이지의 주인인지 확인"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저 식별값(id)"),
+                                fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
+                                fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("유저 API - 본인 유저 페이지 정보 조회하기")
+    void getInfoMyPage() throws Exception {
+        UserInfoResponseDto response = UserInfoResponseDto.builder()
+                .isMyPage(true)
+                .id(1L)
+                .nickname("nickname")
+                .profileImgUrl("profile image url")
+                .build();
+
+        given(userService.getInfo(any(),any())).willReturn(response);
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders
+                                .get("/v1/user/")
+                                .header(AUTHORIZATION_HEADER, "access token"))
+                .andExpect(status().isOk())
+                .andDo(document("user/me",
+                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) JWT Access Token")
+                        ),
+                        responseFields(
+                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data.isMyPage").type(JsonFieldType.BOOLEAN).description("접속자가 해당 페이지의 주인인지 확인"),
                                 fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저 식별값(id)"),
                                 fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
                                 fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크")


### PR DESCRIPTION
❗️ 이슈 번호
close #82 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
기존 유저 정보 조회 API를 유저페이지 정보 조회를 위한 API 로 변경했습니다.

 `GET /v1/user/` : 본인 유저 정보가 필요하거나, 본인의 유저 페이지를 조회하는 경우
 `GET /v1/user/{userId}` : 다른 유저페이지를 조회하는 경우

문서화는 이렇게 적용했습니다.

<img width="777" alt="스크린샷 2023-02-17 오후 3 45 21" src="https://user-images.githubusercontent.com/76773202/219569645-0875c9d5-7aa4-46d9-84da-a18efbfe9fde.png">


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
