### PR TITLE
fix: Redis 운영환경 및 테스트 설정 정보 수정

### DIFF
--- a/src/main/java/com/nexters/phochak/config/EmbeddedRedisConfig.java
+++ b/src/main/java/com/nexters/phochak/config/EmbeddedRedisConfig.java
@@ -20,13 +20,15 @@ public class EmbeddedRedisConfig {
 
     @Value("${spring.redis.port}")
     private int redisPort;
+    @Value("${spring.redis.password}")
+    private String redisPassword;
 
     private RedisServer redisServer;
 
     @PostConstruct
     public void redisServer() throws IOException {
         int port = isRedisRunning()? findAvailablePort() : redisPort;
-        redisServer = new RedisServer(port);
+        redisServer = RedisServer.builder().port(port).setting("requirepass " + redisPassword).build();
         redisServer.start();
     }
 

--- a/src/main/java/com/nexters/phochak/config/RedisConfig.java
+++ b/src/main/java/com/nexters/phochak/config/RedisConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
@@ -15,13 +16,18 @@ public class RedisConfig {
 
     @Value("${spring.redis.host}")
     private String host;
-
     @Value("${spring.redis.port}")
     private int port;
+    @Value("${spring.redis.password}")
+    private String password;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
   redis:
     host: localhost
     port: 6379
+    password: qpdjrmflftm
 # 카카오 OAUTH 관련 설정
 # TODO: 배포 환경별로 분리 필요, 운영에서는 secret key 적용하고 별도로 관리 필요 (애플 로그인이 어떻게 돼있는지 모름)
 kakao:


### PR DESCRIPTION
❗️ 이슈 번호
close #88 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
embedded redis 와 같이 만지다가 운영 파일이 잘못되버렸네요.

운영서버 테스트 완료했습니다!


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

로컬이랑 테스트(임베디드)에 사용되는 Redis는 비밀번호를 걸고 싶지 않았는데,
config 파일에 if(~~==null) 을 넣고싶지는 않아서, 그냥 로컬 mysql 처럼 비밀번호를 넣었습니다 ..

로컬 redis 실행 시 다음 커맨드를 실행하시면 될 것 같습니다.
`docker run --name redis -d -p 6379:6379 redis --requirepass "qpdjrmflftm"`


💡 참고 자료
(없다면 지워도 됩니다!)

https://www.programcreek.com/java-api-examples/?code=tianheframe%2Fdubbo-2.6.5%2Fdubbo-2.6.5-master%2Fdubbo-rpc%2Fdubbo-rpc-redis%2Fsrc%2Ftest%2Fjava%2Fcom%2Falibaba%2Fdubbo%2Frpc%2Fprotocol%2Fredis%2FRedisProtocolTest.java
