### PR TITLE
feat: 내가 포착(좋아요)한 게시글 보기 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,17 @@
+//querydsl 추가
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.7'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+	//querydsl 추가
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'com.nexters'
@@ -79,7 +88,8 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.29'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'com.querydsl:querydsl-jpa'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 	implementation platform('com.amazonaws:aws-java-sdk-bom:1.11.238')
 	implementation 'com.amazonaws:aws-java-sdk-s3'
 	implementation 'com.github.maricn:logback-slack-appender:1.4.0'
@@ -89,7 +99,6 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
-	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
 	// java.lang.NoClassDefFoundError(javax.annotation.Entity) 발생 대응
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	// java.lang.NoClassDefFoundError(javax.annotation.Generated) 발생 대응
@@ -102,4 +111,24 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//querydsl 추가
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -103,6 +103,29 @@ Response Parameters
 
 include::{snippets}/post/list/uploaded/response-fields.adoc[]
 
+==== 내가 좋아요한 게시글 목록
+HTTP Example
+
+include::{snippets}/post/list/liked/http-request.adoc[]
+
+Request Parameters
+
+include::{snippets}/post/list/liked/request-parameters.adoc[]
+
+Request Headers
+
+include::{snippets}/post/list/liked/request-headers.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/post/list/liked/http-response.adoc[]
+
+Response Parameters
+
+include::{snippets}/post/list/liked/response-fields.adoc[]
+
 === Presigned URL 발급
 S3 버킷에 미디어를 업로드 하기 위해, Presigned URL, upload key를 발급한다.
 

--- a/src/main/java/com/nexters/phochak/domain/Shorts.java
+++ b/src/main/java/com/nexters/phochak/domain/Shorts.java
@@ -1,6 +1,5 @@
 package com.nexters.phochak.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nexters.phochak.specification.ShortsStateEnum;
 import lombok.Builder;
@@ -28,7 +27,6 @@ public class Shorts {
     @Column(nullable = false, unique = false)
     private ShortsStateEnum shortsStateEnum;
 
-    @JsonIgnore
     @Column(nullable = false, unique = true)
     private String uploadKey;
 

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -1,6 +1,5 @@
 package com.nexters.phochak.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.nexters.phochak.specification.OAuthProviderEnum;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,11 +25,9 @@ public class User extends BaseTime {
     @Column(name = "USER_ID")
     private Long id;
 
-    @JsonIgnore
     @Enumerated(EnumType.STRING)
     private OAuthProviderEnum provider;
 
-    @JsonIgnore
     @Column(nullable = false, unique = true)
     private String providerId;
 

--- a/src/main/java/com/nexters/phochak/dto/HashtagFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/HashtagFetchDto.java
@@ -1,0 +1,30 @@
+package com.nexters.phochak.dto;
+
+import com.nexters.phochak.domain.Hashtag;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+@Getter
+public class HashtagFetchDto {
+    List<String> hashtags;
+
+    public static HashtagFetchDto from(List<Hashtag> hashtag) {
+        List<String> hashtags = hashtag.stream()
+                .map(Hashtag::getTag)
+                .collect(Collectors.toList());
+
+        return HashtagFetchDto.builder()
+                .hashtags(hashtags)
+                .build();
+    }
+
+    @QueryProjection
+    public HashtagFetchDto(List<String> hashtags) {
+        this.hashtags = hashtags;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/LikesFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/LikesFetchDto.java
@@ -1,0 +1,17 @@
+package com.nexters.phochak.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class LikesFetchDto {
+
+    private boolean isLiked;
+
+    @QueryProjection
+    public LikesFetchDto(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
@@ -35,7 +35,11 @@ public class PostFetchCommand {
     }
 
     public boolean hasUploadedFilter() {
-        return filter.isUploadedFilter();
+        return Objects.equals(filter, PostFilter.UPLOADED);
+    }
+
+    public boolean hasLikedFilter() {
+        return Objects.equals(filter, PostFilter.LIKED);
     }
 
     public String createCursorString() {

--- a/src/main/java/com/nexters/phochak/dto/PostFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchDto.java
@@ -1,0 +1,75 @@
+package com.nexters.phochak.dto;
+
+import com.nexters.phochak.specification.PostCategoryEnum;
+import com.nexters.phochak.specification.ShortsStateEnum;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@Builder
+public class PostFetchDto {
+    private long id;
+    private PostUserInformation user;
+    private PostShortsInformation shorts;
+    private long view;
+    private PostCategoryEnum category;
+    private int like;
+
+    @QueryProjection
+    public PostFetchDto(long id, PostUserInformation user, PostShortsInformation shorts, long view, PostCategoryEnum category, int like) {
+        this.id = id;
+        this.user = user;
+        this.shorts = shorts;
+        this.view = view;
+        this.category = category;
+        this.like = like;
+    }
+
+    @QueryProjection
+    public PostFetchDto(long id, PostUserInformation user, PostShortsInformation shorts, long view, PostCategoryEnum category, long like) {
+        this.id = id;
+        this.user = user;
+        this.shorts = shorts;
+        this.view = view;
+        this.category = category;
+        this.like = (int) like;
+    }
+
+    @Builder
+    @NoArgsConstructor
+    @Getter
+    public static class PostUserInformation {
+        private long id;
+        private String nickname;
+        private String profileImgUrl;
+
+        @QueryProjection
+        public PostUserInformation(long id, String nickname, String profileImgUrl) {
+            this.id = id;
+            this.nickname = nickname;
+            this.profileImgUrl = profileImgUrl;
+        }
+    }
+
+    @Builder
+    @NoArgsConstructor
+    @Getter
+    public static class PostShortsInformation {
+        private Long id;
+        private ShortsStateEnum shortsStateEnum;
+        private String shortsUrl;
+        private String thumbnailUrl;
+
+        @QueryProjection
+        public PostShortsInformation(Long id, ShortsStateEnum shortsStateEnum, String shortsUrl, String thumbnailUrl) {
+            this.id = id;
+            this.shortsStateEnum = shortsStateEnum;
+            this.shortsUrl = shortsUrl;
+            this.thumbnailUrl = thumbnailUrl;
+        }
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/PostFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchDto.java
@@ -60,14 +60,14 @@ public class PostFetchDto {
     @Getter
     public static class PostShortsInformation {
         private Long id;
-        private ShortsStateEnum shortsStateEnum;
+        private ShortsStateEnum state;
         private String shortsUrl;
         private String thumbnailUrl;
 
         @QueryProjection
-        public PostShortsInformation(Long id, ShortsStateEnum shortsStateEnum, String shortsUrl, String thumbnailUrl) {
+        public PostShortsInformation(Long id, ShortsStateEnum state, String shortsUrl, String thumbnailUrl) {
             this.id = id;
-            this.shortsStateEnum = shortsStateEnum;
+            this.state = state;
             this.shortsUrl = shortsUrl;
             this.thumbnailUrl = thumbnailUrl;
         }

--- a/src/main/java/com/nexters/phochak/dto/request/PostFilter.java
+++ b/src/main/java/com/nexters/phochak/dto/request/PostFilter.java
@@ -4,9 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum PostFilter {
-    UPLOADED; // 내가 업로드한 동영상
-
-    public boolean isUploadedFilter() {
-        return this == PostFilter.UPLOADED;
-    }
+    UPLOADED,  // 내가 업로드한 동영상
+    LIKED; // 내가 좋아요한 동영상
 }

--- a/src/main/java/com/nexters/phochak/dto/response/PostPageResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/PostPageResponseDto.java
@@ -1,55 +1,43 @@
 package com.nexters.phochak.dto.response;
 
-import com.nexters.phochak.domain.Hashtag;
-import com.nexters.phochak.domain.Post;
-import com.nexters.phochak.domain.Shorts;
-import com.nexters.phochak.domain.User;
+import com.nexters.phochak.dto.HashtagFetchDto;
+import com.nexters.phochak.dto.LikesFetchDto;
+import com.nexters.phochak.dto.PostFetchDto;
 import com.nexters.phochak.specification.PostCategoryEnum;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
-@Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
 public class PostPageResponseDto {
     private long id;
-    private User user;
-    private Shorts shorts;
+    private PostFetchDto.PostUserInformation user;
+    private PostFetchDto.PostShortsInformation shorts;
     private List<String> hashtags;
     private long view;
     private PostCategoryEnum category;
-    private long like;
+    private int like;
     private Boolean isLiked;
 
-    public static PostPageResponseDto from(Post post, Long userId) {
+    public static PostPageResponseDto of(
+            PostFetchDto postFetchDto, HashtagFetchDto hashtagFetchDto, LikesFetchDto likesFetchDto) {
         return PostPageResponseDto.builder()
-                .id(post.getId())
-                .user(post.getUser())
-                .shorts(post.getShorts())
-                .hashtags(post.getHashtags().stream().map(Hashtag::getTag).collect(Collectors.toList()))
-                .view(post.getView())
-                .category(post.getPostCategory())
-                .like(post.getLikes().size())
-                .isLiked(post.getLikes().stream().anyMatch(likes -> likes.hasLikesByUser(userId)))
+                .id(postFetchDto.getId())
+                .user(postFetchDto.getUser())
+                .shorts(postFetchDto.getShorts())
+                .hashtags(Objects.isNull(hashtagFetchDto) ? Collections.emptyList() : hashtagFetchDto.getHashtags())
+                .view(postFetchDto.getView())
+                .category(postFetchDto.getCategory())
+                .like(postFetchDto.getLike())
+                .isLiked(Objects.isNull(likesFetchDto) ? false : likesFetchDto.isLiked())
                 .build();
-    }
-
-    @Getter
-    private static class HashTagsDto {
-        private final List<String> tags;
-
-        private HashTagsDto(List<String> tags) {
-            this.tags = tags;
-        }
-
-        public static HashTagsDto from(List<Hashtag> hashtags) {
-            List<String> tags = hashtags.stream().map(Hashtag::getTag).collect(Collectors.toList());
-            return new HashTagsDto(tags);
-        }
     }
 }

--- a/src/main/java/com/nexters/phochak/repository/HashtagCustomRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/HashtagCustomRepository.java
@@ -1,0 +1,10 @@
+package com.nexters.phochak.repository;
+
+import com.nexters.phochak.dto.HashtagFetchDto;
+
+import java.util.List;
+import java.util.Map;
+
+public interface HashtagCustomRepository {
+    Map<Long, HashtagFetchDto> findHashTagsOfPost(List<Long> postIds);
+}

--- a/src/main/java/com/nexters/phochak/repository/HashtagRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/HashtagRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagCustomRepository {
 
     @Query("delete from Hashtag h where h.post.id = :postId")
     @Modifying

--- a/src/main/java/com/nexters/phochak/repository/LikesCustomRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/LikesCustomRepository.java
@@ -1,0 +1,14 @@
+package com.nexters.phochak.repository;
+
+import com.nexters.phochak.dto.LikesFetchDto;
+import com.nexters.phochak.dto.PostFetchCommand;
+import com.nexters.phochak.dto.PostFetchDto;
+
+import java.util.List;
+import java.util.Map;
+
+public interface LikesCustomRepository {
+    Map<Long, LikesFetchDto> checkIsLikedPost(List<Long> postIds, Long userId);
+
+    List<PostFetchDto> findLikedPosts(PostFetchCommand command);
+}

--- a/src/main/java/com/nexters/phochak/repository/LikesRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/LikesRepository.java
@@ -7,8 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface LikesRepository extends JpaRepository<Likes, Long> {
+public interface LikesRepository extends JpaRepository<Likes, Long>, LikesCustomRepository {
     boolean existsByUserAndPost(User user, Post post);
-
     Optional<Likes> findByUserAndPost(User user, Post post);
 }

--- a/src/main/java/com/nexters/phochak/repository/PostCustomRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/PostCustomRepository.java
@@ -1,10 +1,10 @@
 package com.nexters.phochak.repository;
 
 import com.nexters.phochak.dto.PostFetchCommand;
-import com.nexters.phochak.dto.response.PostPageResponseDto;
+import com.nexters.phochak.dto.PostFetchDto;
 
 import java.util.List;
 
 public interface PostCustomRepository {
-    List<PostPageResponseDto> findNextPageByCursor(PostFetchCommand command);
+    List<PostFetchDto> findNextPageByCursor(PostFetchCommand command);
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/HashtagCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/HashtagCustomRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.nexters.phochak.repository.impl;
+
+import com.nexters.phochak.domain.QHashtag;
+import com.nexters.phochak.dto.HashtagFetchDto;
+import com.nexters.phochak.dto.QHashtagFetchDto;
+import com.nexters.phochak.repository.HashtagCustomRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@RequiredArgsConstructor
+public class HashtagCustomRepositoryImpl implements HashtagCustomRepository {
+    private static final QHashtag hashtag = QHashtag.hashtag;
+
+    private final JPAQueryFactory queryFactory;
+    @Override
+    public Map<Long, HashtagFetchDto> findHashTagsOfPost(List<Long> postIds) {
+        return queryFactory.from(hashtag)
+                .where(hashtag.post.id.in(postIds))
+                .transform(groupBy(hashtag.post.id)
+                        .as(new QHashtagFetchDto(list(hashtag.tag))));
+    }
+}

--- a/src/main/java/com/nexters/phochak/repository/impl/LikesCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/LikesCustomRepositoryImpl.java
@@ -1,0 +1,117 @@
+package com.nexters.phochak.repository.impl;
+
+import com.nexters.phochak.domain.QLikes;
+import com.nexters.phochak.domain.QPost;
+import com.nexters.phochak.domain.QShorts;
+import com.nexters.phochak.dto.LikesFetchDto;
+import com.nexters.phochak.dto.PostFetchCommand;
+import com.nexters.phochak.dto.PostFetchDto;
+import com.nexters.phochak.dto.QLikesFetchDto;
+import com.nexters.phochak.dto.QPostFetchDto;
+import com.nexters.phochak.dto.QPostFetchDto_PostShortsInformation;
+import com.nexters.phochak.dto.QPostFetchDto_PostUserInformation;
+import com.nexters.phochak.exception.PhochakException;
+import com.nexters.phochak.exception.ResCode;
+import com.nexters.phochak.repository.LikesCustomRepository;
+import com.nexters.phochak.specification.PostSortOption;
+import com.querydsl.core.types.NullExpression;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.StringExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.querydsl.core.group.GroupBy.groupBy;
+import static com.querydsl.core.group.GroupBy.list;
+
+@RequiredArgsConstructor
+public class LikesCustomRepositoryImpl implements LikesCustomRepository {
+    private static final int ID_PADDING = 19;
+    private static final int CRITERIA_PADDING = 10;
+    public static final char ZERO = '0';
+    private static final QLikes likes = QLikes.likes;
+    private static final QPost post = QPost.post;
+    private static final QShorts shorts = QShorts.shorts;
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Map<Long, LikesFetchDto> checkIsLikedPost(List<Long> postIds, Long userId) {
+        Map<Long, LikesFetchDto> result = new HashMap<>();
+
+        Map<Long, List<LikesFetchDto>> map = queryFactory.from(likes)
+                .join(likes.post)
+                .where(likes.post.id.in(postIds))
+                .transform(groupBy(likes.post.id)
+                        .as(list(new QLikesFetchDto(likes.user.id.eq(userId)))));
+
+        map.keySet().forEach(k -> {
+                            LikesFetchDto likesFetchDto = map.get(k).stream().parallel()
+                                    .filter(LikesFetchDto::isLiked)
+                                    .findAny()
+                                    .orElseGet(() -> new LikesFetchDto(false));
+                            result.put(k, likesFetchDto);
+                        }
+                );
+
+        return result;
+    }
+
+    @Override
+    public List<PostFetchDto> findLikedPosts(PostFetchCommand command) {
+        Map<Long, PostFetchDto> result = queryFactory.select(likes, post)
+                .from(likes)
+                .join(post).on(likes.post.eq(post))
+                .join(likes.user)
+                .join(likes.post.shorts)
+                .join(shorts).on(likes.post.shorts.eq(shorts))
+                .where(likes.user.id.eq(command.getUserId()))
+                .where(filterByCursor(command))
+                .limit(command.getPageSize())
+                .orderBy(orderByPostSortOption(command.getSortOption())) // 커서 정렬 조건
+                .orderBy(post.id.desc())
+                .groupBy(post.id)
+                .transform(groupBy(post.id).as(
+                        new QPostFetchDto(post.id,
+                                new QPostFetchDto_PostUserInformation(likes.user.id, likes.user.nickname, likes.user.profileImgUrl),
+                                new QPostFetchDto_PostShortsInformation(shorts.id, shorts.shortsStateEnum, shorts.shortsUrl, shorts.thumbnailUrl),
+                                likes.post.view, likes.post.postCategory, post.likes.size())
+                ));
+
+        return result.keySet().stream()
+                .map(result::get)
+                .collect(Collectors.toList());
+    }
+
+    private BooleanExpression filterByCursor(PostFetchCommand command) {
+        String cursorString = command.createCursorString();
+        switch (command.getSortOption()) {
+            case LATEST:
+                return likes.post.id.lt(command.getLastId());
+            case VIEW:
+                return StringExpressions.lpad(likes.post.view.stringValue(), CRITERIA_PADDING, ZERO)
+                        .concat(StringExpressions.lpad(likes.post.id.stringValue(), ID_PADDING, ZERO))
+                        .lt(cursorString);
+            case LIKE:
+                return StringExpressions.lpad(likes.count().stringValue(), CRITERIA_PADDING, ZERO)
+                        .concat(StringExpressions.lpad(likes.post.id.stringValue(), ID_PADDING, ZERO))
+                        .lt(cursorString);
+        }
+        throw new PhochakException(ResCode.NOT_SUPPORTED_SORT_OPTION);
+    }
+
+    private static OrderSpecifier orderByPostSortOption(PostSortOption postSortOption) {
+        if (postSortOption == PostSortOption.LIKE) {
+            return likes.count().desc();
+        } else if (postSortOption == PostSortOption.VIEW) {
+            return likes.post.view.desc();
+        }
+        return new OrderSpecifier(Order.ASC, NullExpression.DEFAULT, OrderSpecifier.NullHandling.Default);
+    }
+}

--- a/src/main/java/com/nexters/phochak/service/HashtagService.java
+++ b/src/main/java/com/nexters/phochak/service/HashtagService.java
@@ -2,10 +2,13 @@ package com.nexters.phochak.service;
 
 import com.nexters.phochak.domain.Hashtag;
 import com.nexters.phochak.domain.Post;
+import com.nexters.phochak.dto.HashtagFetchDto;
 
 import java.util.List;
+import java.util.Map;
 
 public interface HashtagService {
     List<Hashtag> saveHashtagsByString(List<String> stringHashtagList, Post post);
 
+    Map<Long, HashtagFetchDto> findHashtagsOfPosts(List<Long> postIds);
 }

--- a/src/main/java/com/nexters/phochak/service/LikesService.java
+++ b/src/main/java/com/nexters/phochak/service/LikesService.java
@@ -1,0 +1,14 @@
+package com.nexters.phochak.service;
+
+import com.nexters.phochak.dto.LikesFetchDto;
+import com.nexters.phochak.dto.PostFetchCommand;
+import com.nexters.phochak.dto.PostFetchDto;
+
+import java.util.List;
+import java.util.Map;
+
+public interface LikesService {
+    Map<Long, LikesFetchDto> checkIsLikedPost(List<Long> postIds, Long userId);
+
+    List<PostFetchDto> findLikedPosts(PostFetchCommand command);
+}

--- a/src/main/java/com/nexters/phochak/service/impl/HashtagServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/HashtagServiceImpl.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.service.impl;
 
 import com.nexters.phochak.domain.Hashtag;
 import com.nexters.phochak.domain.Post;
+import com.nexters.phochak.dto.HashtagFetchDto;
 import com.nexters.phochak.exception.PhochakException;
 import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.repository.HashtagRepository;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Matcher;
+import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,11 @@ public class HashtagServiceImpl implements HashtagService {
                         .build()
         ).collect(Collectors.toList());
         return hashtagRepository.saveAll(hashtagList);
+    }
+
+    @Override
+    public Map<Long, HashtagFetchDto> findHashtagsOfPosts(List<Long> postIds) {
+        return hashtagRepository.findHashTagsOfPost(postIds);
     }
 
     private static void validateHashtag(List<String> stringHashtagList) {

--- a/src/main/java/com/nexters/phochak/service/impl/LikeServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/LikeServiceImpl.java
@@ -1,0 +1,28 @@
+package com.nexters.phochak.service.impl;
+
+import com.nexters.phochak.dto.LikesFetchDto;
+import com.nexters.phochak.dto.PostFetchCommand;
+import com.nexters.phochak.dto.PostFetchDto;
+import com.nexters.phochak.repository.LikesRepository;
+import com.nexters.phochak.service.LikesService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+public class LikeServiceImpl implements LikesService {
+    private final LikesRepository likesRepository;
+
+    @Override
+    public Map<Long, LikesFetchDto> checkIsLikedPost(List<Long> postIds, Long userId) {
+        return likesRepository.checkIsLikedPost(postIds, userId);
+    }
+
+    @Override
+    public List<PostFetchDto> findLikedPosts(PostFetchCommand command) {
+        return likesRepository.findLikedPosts(command);
+    }
+}

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -1,15 +1,15 @@
 package com.nexters.phochak.controller;
 
 import com.nexters.phochak.docs.RestDocs;
-import com.nexters.phochak.domain.Shorts;
-import com.nexters.phochak.domain.User;
+import com.nexters.phochak.dto.PostFetchDto.PostShortsInformation;
+import com.nexters.phochak.dto.PostFetchDto.PostUserInformation;
 import com.nexters.phochak.dto.request.CustomCursor;
 import com.nexters.phochak.dto.request.PostFilter;
 import com.nexters.phochak.dto.response.PostPageResponseDto;
 import com.nexters.phochak.service.PostService;
-import com.nexters.phochak.specification.OAuthProviderEnum;
 import com.nexters.phochak.specification.PostCategoryEnum;
 import com.nexters.phochak.specification.PostSortOption;
+import com.nexters.phochak.specification.ShortsStateEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,25 +51,24 @@ class PostControllerTest extends RestDocs {
     PostController postController;
 
     MockMvc mockMvc;
-    User user;
-    Shorts shorts;
+    PostUserInformation user;
+    PostShortsInformation shorts;
     PostPageResponseDto post1;
     PostPageResponseDto post2;
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider restDocumentation) {
         this.mockMvc = getMockMvcBuilder(restDocumentation, postController).build();
-        user = User.builder()
-                .id(3L)
-                .provider(OAuthProviderEnum.KAKAO)
-                .providerId("123456789")
+
+        user = PostUserInformation.builder()
+                .id(3)
                 .nickname("testUser")
                 .profileImgUrl("profileImage")
                 .build();
 
-        shorts = Shorts.builder()
+        shorts = PostShortsInformation.builder()
                 .id(1L)
-                .uploadKey("key")
+                .state(ShortsStateEnum.OK)
                 .thumbnailUrl("thumbnail url")
                 .shortsUrl("shorts url")
                 .build();
@@ -83,7 +82,7 @@ class PostControllerTest extends RestDocs {
                 .shorts(shorts)
                 .view(5L)
                 .category(PostCategoryEnum.RESTAURANT)
-                .like(10L)
+                .like(10)
                 .isLiked(Boolean.TRUE)
                 .hashtags(hashtags1)
                 .build();
@@ -94,7 +93,7 @@ class PostControllerTest extends RestDocs {
                 .shorts(shorts)
                 .view(12L)
                 .category(PostCategoryEnum.TOUR)
-                .like(21L)
+                .like(21)
                 .isLiked(Boolean.FALSE)
                 .hashtags(hashtags2)
                 .build();
@@ -197,7 +196,7 @@ class PostControllerTest extends RestDocs {
                 .shorts(shorts)
                 .view(50L)
                 .category(PostCategoryEnum.TOUR)
-                .like(75L)
+                .like(75)
                 .isLiked(Boolean.TRUE)
                 .hashtags(hashtags)
                 .build();
@@ -335,10 +334,8 @@ class PostControllerTest extends RestDocs {
 
         List<String> hashtags = List.of("내가", "업로드");
 
-        User newUser = User.builder()
+        PostUserInformation newUser = PostUserInformation.builder()
                 .id(4L)
-                .provider(OAuthProviderEnum.KAKAO)
-                .providerId("123456789")
                 .nickname("newUser")
                 .profileImgUrl("profileImage")
                 .build();
@@ -378,7 +375,89 @@ class PostControllerTest extends RestDocs {
                                 parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
                                 parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
                                 parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상)")
+                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                        ),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) JWT Access Token")
+                        ),
+                        responseFields(
+                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("isLastPage").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("게시글 id"),
+                                fieldWithPath("data[].user.id").type(JsonFieldType.NUMBER).description("유저 id"),
+                                fieldWithPath("data[].user.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
+                                fieldWithPath("data[].user.profileImgUrl").type(JsonFieldType.STRING).description("유저 프로필 이미지 링크"),
+                                fieldWithPath("data[].shorts.id").type(JsonFieldType.NUMBER).description("영상 id"),
+                                fieldWithPath("data[].shorts.state").type(JsonFieldType.STRING).description("현재 shorts 인코딩 상태(OK, FAIL, IN_PROGRESS)"),
+                                fieldWithPath("data[].shorts.thumbnailUrl").type(JsonFieldType.STRING).description("영상 썸네일 이미지 링크"),
+                                fieldWithPath("data[].shorts.shortsUrl").type(JsonFieldType.STRING).description("영상 링크"),
+                                fieldWithPath("data[].hashtags").type(JsonFieldType.ARRAY).description("해시태그 목록"),
+                                fieldWithPath("data[].view").type(JsonFieldType.NUMBER).description("조회수"),
+                                fieldWithPath("data[].category").type(JsonFieldType.STRING).description("게시글 카테고리"),
+                                fieldWithPath("data[].like").type(JsonFieldType.NUMBER).description("좋아요 수"),
+                                fieldWithPath("data[].isLiked").type(JsonFieldType.BOOLEAN).description("조회한 유저의 좋아요 여부")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("포스트 목록 조회 API - 내가 좋아요한 영상")
+    void getPostList_liked() throws Exception {
+        CustomCursor customCursor = CustomCursor.builder()
+                .pageSize(3)
+                .sortOption(PostSortOption.LIKE)
+                .lastId(20L)
+                .sortValue(75)
+                .build();
+
+        PostFilter postFilter = PostFilter.LIKED;
+
+        List<String> hashtags = List.of("좋아요한", "게시글");
+
+        PostUserInformation newUser = PostUserInformation.builder()
+                .id(4L)
+                .nickname("newUser")
+                .profileImgUrl("profileImage")
+                .build();
+
+        PostPageResponseDto post3 = PostPageResponseDto.builder()
+                .id(20L)
+                .user(newUser)
+                .shorts(shorts)
+                .view(1000)
+                .category(PostCategoryEnum.CAFE)
+                .like(120)
+                .isLiked(Boolean.TRUE)
+                .hashtags(hashtags)
+                .build();
+
+        List<PostPageResponseDto> result = List.of(post3, post1);
+
+
+        when(postService.getNextCursorPage(any(), any())).thenReturn(result);
+
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders
+                                .get("/v1/post/list")
+                                .param("sortValue", String.valueOf(customCursor.getSortValue()))
+                                .param("lastId", String.valueOf(customCursor.getLastId()))
+                                .param("sortOption", customCursor.getSortOption().name())
+                                .param("pageSize", String.valueOf(customCursor.getPageSize()))
+                                .param("filter", postFilter.name())
+                                .header(AUTHORIZATION_HEADER, "access token")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("post/list/liked",
+                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                                parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
+                                parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
+                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
+                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)


### PR DESCRIPTION
❗️ 이슈 번호
close #78 


📝 구현 내용
- 좋아요된 게시글을 필터링해올 수 있도록 개발했습니다...!
- 조회 흐름 
  - 페이징을 위해 커서 조건/필터 조건(마이페이지용)/페이지 사이즈로 post 조회 (이 때, user/shorts는 N:1, 1:1 관계라서 join)  
    - dto로 리턴함
  - 위에서 받은 각 게시글의 id를 통해 각 게시글에 있는 해시태그를 가져오기 위해 hashtag 조회
    - dto로 리턴함
  - 좋아요 여부를 확인하기 위해 각 게시글 id의 좋아요를 가져와서 메모리 상에서 user id와 대조
    - dto로 리턴함
    - 이 부분이 좀 비효율적인것 같은데.... 딱히 방법을 못찾았습니다
  - 최종적으로 dto들을 조합하여 응답


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
기존 조회방식도 다 뜯어고치다보니 개발량이 많은데 일단 어느정도 정리가 된거같아서 올려봅니다... 피드백하실 곳 있으면 말씀 주세용..


💡 참고 자료
(없다면 지워도 됩니다!)
