### PR TITLE
feat: 운영 데이터베이스 DDL 작성 및 필요한 인덱스 정의

### DIFF
--- a/src/main/java/com/nexters/phochak/dto/LikesFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/LikesFetchDto.java
@@ -1,6 +1,5 @@
 package com.nexters.phochak.dto;
 
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -8,10 +7,11 @@ import lombok.ToString;
 @Getter
 public class LikesFetchDto {
 
+    private int like;
     private boolean isLiked;
 
-    @QueryProjection
-    public LikesFetchDto(boolean isLiked) {
+    public LikesFetchDto(int like, boolean isLiked) {
+        this.like = like;
         this.isLiked = isLiked;
     }
 }

--- a/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
@@ -13,9 +13,6 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Getter
 public class PostFetchCommand {
-    private static final String INTEGER_STRING_FORMATTER = "%010d";
-    private static final String LONG_STRING_FORMATTER = "%019d";
-
     private final long userId;
     private final Long lastId;
     private final Integer pageSize;
@@ -40,13 +37,5 @@ public class PostFetchCommand {
 
     public boolean hasLikedFilter() {
         return Objects.equals(filter, PostFilter.LIKED);
-    }
-
-    public String createCursorString() {
-        if (Objects.isNull(sortValue)) {
-            return null;
-        }
-
-        return String.format(INTEGER_STRING_FORMATTER, sortValue) + String.format(LONG_STRING_FORMATTER, lastId);
     }
 }

--- a/src/main/java/com/nexters/phochak/dto/PostFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchDto.java
@@ -17,26 +17,14 @@ public class PostFetchDto {
     private PostShortsInformation shorts;
     private long view;
     private PostCategoryEnum category;
-    private int like;
 
     @QueryProjection
-    public PostFetchDto(long id, PostUserInformation user, PostShortsInformation shorts, long view, PostCategoryEnum category, int like) {
+    public PostFetchDto(long id, PostUserInformation user, PostShortsInformation shorts, long view, PostCategoryEnum category) {
         this.id = id;
         this.user = user;
         this.shorts = shorts;
         this.view = view;
         this.category = category;
-        this.like = like;
-    }
-
-    @QueryProjection
-    public PostFetchDto(long id, PostUserInformation user, PostShortsInformation shorts, long view, PostCategoryEnum category, long like) {
-        this.id = id;
-        this.user = user;
-        this.shorts = shorts;
-        this.view = view;
-        this.category = category;
-        this.like = (int) like;
     }
 
     @Builder

--- a/src/main/java/com/nexters/phochak/dto/QuerydslFetchDto.java
+++ b/src/main/java/com/nexters/phochak/dto/QuerydslFetchDto.java
@@ -1,0 +1,15 @@
+package com.nexters.phochak.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class QuerydslFetchDto {
+
+    private boolean isLiked;
+
+    @QueryProjection
+    public QuerydslFetchDto(boolean isLiked) {
+        this.isLiked = isLiked;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/response/PostPageResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/PostPageResponseDto.java
@@ -36,7 +36,7 @@ public class PostPageResponseDto {
                 .hashtags(Objects.isNull(hashtagFetchDto) ? Collections.emptyList() : hashtagFetchDto.getHashtags())
                 .view(postFetchDto.getView())
                 .category(postFetchDto.getCategory())
-                .like(postFetchDto.getLike())
+                .like(Objects.isNull(likesFetchDto) ? 0 : likesFetchDto.getLike())
                 .isLiked(Objects.isNull(likesFetchDto) ? false : likesFetchDto.isLiked())
                 .build();
     }

--- a/src/main/java/com/nexters/phochak/repository/PostCustomRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/PostCustomRepository.java
@@ -6,5 +6,5 @@ import com.nexters.phochak.dto.PostFetchDto;
 import java.util.List;
 
 public interface PostCustomRepository {
-    List<PostFetchDto> findNextPageByCursor(PostFetchCommand command);
+    List<PostFetchDto> findNextPageByCommmand(PostFetchCommand command);
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/LikesCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/LikesCustomRepositoryImpl.java
@@ -6,10 +6,11 @@ import com.nexters.phochak.domain.QShorts;
 import com.nexters.phochak.dto.LikesFetchDto;
 import com.nexters.phochak.dto.PostFetchCommand;
 import com.nexters.phochak.dto.PostFetchDto;
-import com.nexters.phochak.dto.QLikesFetchDto;
 import com.nexters.phochak.dto.QPostFetchDto;
 import com.nexters.phochak.dto.QPostFetchDto_PostShortsInformation;
 import com.nexters.phochak.dto.QPostFetchDto_PostUserInformation;
+import com.nexters.phochak.dto.QQuerydslFetchDto;
+import com.nexters.phochak.dto.QuerydslFetchDto;
 import com.nexters.phochak.repository.LikesCustomRepository;
 import com.nexters.phochak.specification.PostSortOption;
 import com.nexters.phochak.specification.ShortsStateEnum;
@@ -40,20 +41,22 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository {
     public Map<Long, LikesFetchDto> checkIsLikedPost(List<Long> postIds, Long userId) {
         Map<Long, LikesFetchDto> result = new HashMap<>();
 
-        Map<Long, List<LikesFetchDto>> map = queryFactory.from(likes)
+        Map<Long, List<QuerydslFetchDto>> map = queryFactory.from(likes)
                 .join(likes.post)
                 .where(likes.post.id.in(postIds))
                 .transform(groupBy(likes.post.id)
-                        .as(list(new QLikesFetchDto(likes.user.id.eq(userId)))));
+                        .as(list(new QQuerydslFetchDto(likes.user.id.eq(userId)))));
 
         map.keySet().forEach(k -> {
-                            LikesFetchDto likesFetchDto = map.get(k).stream().parallel()
-                                    .filter(LikesFetchDto::isLiked)
-                                    .findAny()
-                                    .orElseGet(() -> new LikesFetchDto(false));
-                            result.put(k, likesFetchDto);
-                        }
-                );
+                    int size = map.get(k).size();
+                    boolean isLiked = false;
+                    for (int i = 0; i < size; i++) {
+                        if (map.get(k).get(i).isLiked()) {
+                            isLiked = true;
+                            break;
+                        }}
+                    result.put(k, new LikesFetchDto(size, isLiked));
+                });
 
         return result;
     }
@@ -77,7 +80,7 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository {
                         new QPostFetchDto(post.id,
                                 new QPostFetchDto_PostUserInformation(likes.user.id, likes.user.nickname, likes.user.profileImgUrl),
                                 new QPostFetchDto_PostShortsInformation(shorts.id, shorts.shortsStateEnum, shorts.shortsUrl, shorts.thumbnailUrl),
-                                likes.post.view, likes.post.postCategory, post.likes.size())
+                                likes.post.view, likes.post.postCategory)
                 ));
 
         return result.keySet().stream()

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -46,8 +46,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                                 new QPostFetchDto_PostUserInformation(post.user.id, post.user.nickname, post.user.profileImgUrl),
                                 new QPostFetchDto_PostShortsInformation(post.shorts.id, post.shorts.shortsStateEnum, post.shorts.shortsUrl, post.shorts.thumbnailUrl),
                                 post.view,
-                                post.postCategory,
-                                post.likes.size()
+                                post.postCategory
                         )));
 
         return resultMap.keySet().stream()

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -6,8 +6,6 @@ import com.nexters.phochak.dto.PostFetchDto;
 import com.nexters.phochak.dto.QPostFetchDto;
 import com.nexters.phochak.dto.QPostFetchDto_PostShortsInformation;
 import com.nexters.phochak.dto.QPostFetchDto_PostUserInformation;
-import com.nexters.phochak.exception.PhochakException;
-import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.repository.PostCustomRepository;
 import com.nexters.phochak.specification.PostSortOption;
 import com.nexters.phochak.specification.ShortsStateEnum;
@@ -15,7 +13,6 @@ import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.StringExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,15 +26,12 @@ import static com.querydsl.core.group.GroupBy.groupBy;
 @Slf4j
 @RequiredArgsConstructor
 public class PostCustomRepositoryImpl implements PostCustomRepository {
-    private static final int ID_PADDING = 19;
-    private static final int CRITERIA_PADDING = 10;
-    public static final char ZERO = '0';
     private static final QPost post = QPost.post;
 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<PostFetchDto> findNextPageByCursor(PostFetchCommand command) {
+    public List<PostFetchDto> findNextPageByCommmand(PostFetchCommand command) {
         Map<Long, PostFetchDto> resultMap = queryFactory.from(post)
                 .join(post.user)
                 .join(post.shorts)
@@ -70,20 +64,15 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     }
 
     private BooleanExpression filterByCursor(PostFetchCommand command) {
-        String cursorString = command.createCursorString();
+        BooleanExpression defaultFilter = post.id.lt(command.getLastId());
         switch (command.getSortOption()) {
-            case LATEST:
-                return post.id.lt(command.getLastId());
             case VIEW:
-                return StringExpressions.lpad(post.view.stringValue(), CRITERIA_PADDING, ZERO)
-                        .concat(StringExpressions.lpad(post.id.stringValue(), ID_PADDING, ZERO))
-                        .lt(cursorString);
+                return post.view.loe(command.getSortValue()).and(defaultFilter);
             case LIKE:
-                return StringExpressions.lpad(post.likes.size().stringValue(), CRITERIA_PADDING, ZERO)
-                        .concat(StringExpressions.lpad(post.id.stringValue(), ID_PADDING, ZERO))
-                        .lt(cursorString);
+                return post.likes.size().loe(command.getSortValue()).and(defaultFilter);
+            default:
+                return defaultFilter;
         }
-        throw new PhochakException(ResCode.NOT_SUPPORTED_SORT_OPTION);
     }
 
     private static OrderSpecifier orderByPostSortOption(PostSortOption postSortOption) {

--- a/src/main/java/com/nexters/phochak/service/LikesService.java
+++ b/src/main/java/com/nexters/phochak/service/LikesService.java
@@ -10,5 +10,5 @@ import java.util.Map;
 public interface LikesService {
     Map<Long, LikesFetchDto> checkIsLikedPost(List<Long> postIds, Long userId);
 
-    List<PostFetchDto> findLikedPosts(PostFetchCommand command);
+    List<PostFetchDto> findLikedPostsByCommand(PostFetchCommand command);
 }

--- a/src/main/java/com/nexters/phochak/service/impl/LikeServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/LikeServiceImpl.java
@@ -22,7 +22,7 @@ public class LikeServiceImpl implements LikesService {
     }
 
     @Override
-    public List<PostFetchDto> findLikedPosts(PostFetchCommand command) {
+    public List<PostFetchDto> findLikedPostsByCommand(PostFetchCommand command) {
         return likesRepository.findLikedPosts(command);
     }
 }

--- a/src/main/java/com/nexters/phochak/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/PostServiceImpl.java
@@ -13,7 +13,6 @@ import com.nexters.phochak.dto.request.CustomCursor;
 import com.nexters.phochak.dto.request.PostCreateRequestDto;
 import com.nexters.phochak.dto.request.PostFilter;
 import com.nexters.phochak.dto.response.PostPageResponseDto;
-import com.nexters.phochak.dto.PostUploadKeyResponseDto;
 import com.nexters.phochak.exception.PhochakException;
 import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.repository.HashtagRepository;
@@ -92,9 +91,9 @@ public class PostServiceImpl implements PostService {
 
     private List<PostPageResponseDto> createPostPageResponseDto(PostFetchCommand command) {
         if (!command.hasLikedFilter()) {
-            return getNextCursorPageWithoutLikedFilter(command.getUserId(), postRepository.findNextPageByCursor(command));
+            return getNextCursorPageWithoutLikedFilter(command.getUserId(), postRepository.findNextPageByCommmand(command));
         }
-        return getNextCursorPageWithoutLikedFilter(command.getUserId(), likesService.findLikedPosts(command));
+        return getNextCursorPageWithoutLikedFilter(command.getUserId(), likesService.findLikedPostsByCommand(command));
     }
 
     private List<PostPageResponseDto> getNextCursorPageWithoutLikedFilter(Long userId, List<PostFetchDto> postFetchDtos) {

--- a/src/main/resources/sql/V20220225_001_초기테이블_schema.sql
+++ b/src/main/resources/sql/V20220225_001_초기테이블_schema.sql
@@ -1,63 +1,70 @@
-create table `user` (
-                        user_id bigint not null auto_increment,
-                        created_at datetime(6),
-                        updated_at datetime(6),
-                        nickname varchar(10) not null unique,
-                        profile_img_url varchar(255),
-                        provider varchar(255),
-                        provider_id varchar(255) not null unique,
-                        primary key (user_id)
+create table `user`
+(
+    user_id         bigint       not null auto_increment,
+    created_at      datetime(6),
+    updated_at      datetime(6),
+    nickname        varchar(10)  not null unique,
+    profile_img_url varchar(255),
+    provider        varchar(255),
+    provider_id     varchar(255) not null unique,
+    primary key (user_id)
 ) engine=InnoDB
 
-create table hashtag (
-                         tag_id bigint not null auto_increment,
-                         tag varchar(20),
-                         post_id bigint,
-                         primary key (tag_id)
+create table hashtag
+(
+    tag_id  bigint not null auto_increment,
+    tag     varchar(20),
+    post_id bigint,
+    primary key (tag_id)
 ) engine=InnoDB
 
-create table likes (
-                       likes_id bigint not null auto_increment,
-                       created_at datetime(6),
-                       updated_at datetime(6),
-                       post_id bigint,
-                       user_id bigint,
-                       primary key (likes_id)
+create table likes
+(
+    likes_id   bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    post_id    bigint,
+    user_id    bigint,
+    primary key (likes_id)
 ) engine=InnoDB
 
-create table post (
-                      post_id bigint not null auto_increment,
-                      created_at datetime(6),
-                      updated_at datetime(6),
-                      post_category varchar(255) not null,
-                      view bigint default 0 not null,
-                      shorts_id bigint,
-                      user_id bigint,
-                      primary key (post_id)
+create table post
+(
+    post_id       bigint           not null auto_increment,
+    created_at    datetime(6),
+    updated_at    datetime(6),
+    post_category varchar(255)     not null,
+    view          bigint default 0 not null,
+    shorts_id     bigint,
+    user_id       bigint,
+    primary key (post_id)
 ) engine=InnoDB
 
-create table refresh_token (
-                               refresh_token_id bigint not null auto_increment,
-                               refresh_token_string varchar(255),
-                               user_id bigint,
-                               primary key (refresh_token_id)
+create table refresh_token
+(
+    refresh_token_id     bigint not null auto_increment,
+    refresh_token_string varchar(255),
+    user_id              bigint,
+    primary key (refresh_token_id)
 ) engine=InnoDB
 
-create table report_post (
-                             report_id bigint not null auto_increment,
-                             created_at datetime(6),
-                             updated_at datetime(6),
-                             reason varchar(255),
-                             post_id bigint not null,
-                             user_id bigint not null,
-                             primary key (report_id)
+create table report_post
+(
+    report_id  bigint not null auto_increment,
+    created_at datetime(6),
+    updated_at datetime(6),
+    reason     varchar(255),
+    post_id    bigint not null,
+    user_id    bigint not null,
+    primary key (report_id)
 ) engine=InnoDB
 
-create table shorts (
-                        shorts_id bigint not null auto_increment,
-                        shorts_state_enum varchar(255) not null,
-                        shorts_url varchar(255) not null unique,
-                        thumbnail_url varchar(255) not null unique,
-                        upload_key varchar(255) not null unique,
-                        primary key (shorts_id)
+create table shorts
+(
+    shorts_id         bigint       not null auto_increment,
+    shorts_state_enum varchar(255) not null,
+    shorts_url        varchar(255) not null unique,
+    thumbnail_url     varchar(255) not null unique,
+    upload_key        varchar(255) not null unique,
+    primary key (shorts_id)
 ) engine=InnoDB

--- a/src/main/resources/sql/V20220225_001_초기테이블_schema.sql
+++ b/src/main/resources/sql/V20220225_001_초기테이블_schema.sql
@@ -1,0 +1,63 @@
+create table `user` (
+                        user_id bigint not null auto_increment,
+                        created_at datetime(6),
+                        updated_at datetime(6),
+                        nickname varchar(10) not null unique,
+                        profile_img_url varchar(255),
+                        provider varchar(255),
+                        provider_id varchar(255) not null unique,
+                        primary key (user_id)
+) engine=InnoDB
+
+create table hashtag (
+                         tag_id bigint not null auto_increment,
+                         tag varchar(20),
+                         post_id bigint,
+                         primary key (tag_id)
+) engine=InnoDB
+
+create table likes (
+                       likes_id bigint not null auto_increment,
+                       created_at datetime(6),
+                       updated_at datetime(6),
+                       post_id bigint,
+                       user_id bigint,
+                       primary key (likes_id)
+) engine=InnoDB
+
+create table post (
+                      post_id bigint not null auto_increment,
+                      created_at datetime(6),
+                      updated_at datetime(6),
+                      post_category varchar(255) not null,
+                      view bigint default 0 not null,
+                      shorts_id bigint,
+                      user_id bigint,
+                      primary key (post_id)
+) engine=InnoDB
+
+create table refresh_token (
+                               refresh_token_id bigint not null auto_increment,
+                               refresh_token_string varchar(255),
+                               user_id bigint,
+                               primary key (refresh_token_id)
+) engine=InnoDB
+
+create table report_post (
+                             report_id bigint not null auto_increment,
+                             created_at datetime(6),
+                             updated_at datetime(6),
+                             reason varchar(255),
+                             post_id bigint not null,
+                             user_id bigint not null,
+                             primary key (report_id)
+) engine=InnoDB
+
+create table shorts (
+                        shorts_id bigint not null auto_increment,
+                        shorts_state_enum varchar(255) not null,
+                        shorts_url varchar(255) not null unique,
+                        thumbnail_url varchar(255) not null unique,
+                        upload_key varchar(255) not null unique,
+                        primary key (shorts_id)
+) engine=InnoDB

--- a/src/main/resources/sql/V20220225_002_인덱스추가.sql
+++ b/src/main/resources/sql/V20220225_002_인덱스추가.sql
@@ -1,0 +1,12 @@
+-- 유저
+create index idx01_user on user (nickname);
+
+-- 게시글
+create index idx01_post on post (view, post_id);
+create index idx02_post on post (user_id);
+
+-- 해시태그
+create index idx01_hashtag on hashtag (tag);
+
+-- 좋아요
+create index idx01_likes on likes (post_id);

--- a/src/main/resources/sql/V20220225_002_인덱스추가.sql
+++ b/src/main/resources/sql/V20220225_002_인덱스추가.sql
@@ -5,8 +5,8 @@ create index idx01_user on user (nickname);
 create index idx01_post on post (view, post_id);
 create index idx02_post on post (user_id);
 
--- 해시태그
-create index idx01_hashtag on hashtag (tag);
+-- 쇼츠
+create index idx01_shorts on shorts (upload_key);
 
 -- 좋아요
 create index idx01_likes on likes (post_id);


### PR DESCRIPTION
❗️ 이슈 번호
close #43 


📝 구현 내용
- 커서 검색 로직을 그냥 간편하게 구현
- 필요한 index 정의
- post select시 나가는 서브쿼리 하나 제거


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
추가한 인덱스입니다

-- 유저
create index idx01_user on user (nickname);
-> 유저 닉네임 존재 여부 검색 시 사용됩니다

-- 게시글
create index idx01_post on post (view, post_id);
-> view 순 조회 시 커서 조건에 사용됩니다
create index idx02_post on post (user_id);
-> user table과 join할 때 효과적으로 할 수 있도록 사용했습니다

-- 해시태그
~~create index idx01_hashtag on hashtag (tag);~~
~~-> hashtag 검색에 사용됩니다.~~

-- 좋아요
create index idx01_likes on likes (post_id);
-> post 테이블과 join 시 사용됩니다.

-- 쇼츠
create index idx01_shorts on shorts (upload_key);
-> 업로드 키로 탐색할 때 사용됩니다.

💡 참고 자료
(없다면 지워도 됩니다!)
