### PR TITLE
fix: JWT body 요청시 Bearer prefix 미포함 이슈 해결

### DIFF
--- a/src/main/java/com/nexters/phochak/service/impl/JwtTokenServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/JwtTokenServiceImpl.java
@@ -109,6 +109,7 @@ public class JwtTokenServiceImpl implements JwtTokenService {
 
     @Override
     public void logout(String refreshToken) {
+        refreshToken = parseOnlyTokenFromRequest(refreshToken);
         validateJwt(refreshToken);
         refreshTokenRepository.expire(refreshToken);
     }

--- a/src/test/java/com/nexters/phochak/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/integration/AuthIntegrationTest.java
@@ -213,7 +213,7 @@ public class AuthIntegrationTest extends RestDocs {
 
         refreshTokenRepository.saveWithAccessToken(currentRT1.getTokenString(), currentAT1.getTokenString());
 
-        LogoutRequestDto body = new LogoutRequestDto(currentRT1.getTokenString());
+        LogoutRequestDto body = new LogoutRequestDto("Bearer " + currentRT1.getTokenString());
 
         //when, then
         mockMvc.perform(post("/v1/user/logout")
@@ -265,7 +265,7 @@ public class AuthIntegrationTest extends RestDocs {
 
         refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
 
-        WithdrawRequestDto body = new WithdrawRequestDto(currentRT.getTokenString());
+        WithdrawRequestDto body = new WithdrawRequestDto("Bearer " + currentRT.getTokenString());
 
         //when, then
         mockMvc.perform(post("/v1/user/withdraw")


### PR DESCRIPTION
❗️ 이슈 번호
close #113 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
JWT를 body 에 넣어서 요청하는 회원탈퇴 및 로그아웃 로직에서 Bearer prefix 미포함 이슈 해결


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
