### PR TITLE
refactor: 포착 취소시 불필요한 query 제거

### DIFF
--- a/src/main/java/com/nexters/phochak/service/impl/LikeServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/LikeServiceImpl.java
@@ -31,9 +31,6 @@ public class LikeServiceImpl implements LikesService {
     public void addPhochak(Long userId, Long postId) {
         User user = userRepository.getReferenceById(userId);
         Post post = postRepository.findById(postId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_POST));
-        if(likesRepository.existsByUserAndPost(user, post)) {
-            throw new PhochakException(ResCode.ALREADY_PHOCHAKED);
-        }
 
         Likes likes = Likes.builder()
                 .user(user)
@@ -45,7 +42,7 @@ public class LikeServiceImpl implements LikesService {
     @Override
     public void cancelPhochak(Long userId, Long postId) {
         User user = userRepository.getReferenceById(userId);
-        Post post = postRepository.findById(postId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_POST));
+        Post post = postRepository.getReferenceById(postId);
 
         Likes likes = likesRepository.findByUserAndPost(user, post)
                 .orElseThrow(() -> new PhochakException(ResCode.NOT_PHOCHAKED));


### PR DESCRIPTION
❗️ 이슈 번호
close #120


📝 구현 내용
- 포착 취소 시 게시글 조회를 `findBy` -> `getReference`
- 포착 생성 시 중복 여부 쿼리 제거



🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
