### PR TITLE
fix: 유저가 올린 게시글이 없을 경우 회원 탈퇴 예외처리

### DIFF
--- a/src/main/java/com/nexters/phochak/client/impl/NCPStorageClient.java
+++ b/src/main/java/com/nexters/phochak/client/impl/NCPStorageClient.java
@@ -13,6 +13,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.nexters.phochak.client.StorageBucketClient;
 import com.nexters.phochak.config.property.NCPStorageProperties;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Repository;
 
 import java.net.URL;
@@ -57,6 +58,7 @@ public class NCPStorageClient implements StorageBucketClient {
         return s3Client.generatePresignedUrl(originalBucketName, objectName, expiration, HttpMethod.PUT);
     }
 
+    @Async
     @Override
     public void removeShortsObject(List<String> objectKeyList) {
         if (objectKeyList.isEmpty()) return;

--- a/src/main/java/com/nexters/phochak/client/impl/NCPStorageClient.java
+++ b/src/main/java/com/nexters/phochak/client/impl/NCPStorageClient.java
@@ -6,22 +6,19 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
-import com.amazonaws.services.s3.model.DeleteObjectsResult;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.nexters.phochak.client.StorageBucketClient;
 import com.nexters.phochak.config.property.NCPStorageProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Component;
 
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-@Repository
+@Component
 @Slf4j
 public class NCPStorageClient implements StorageBucketClient {
     private final String encodedBucketName;
@@ -61,7 +58,9 @@ public class NCPStorageClient implements StorageBucketClient {
     @Async
     @Override
     public void removeShortsObject(List<String> objectKeyList) {
-        if (objectKeyList.isEmpty()) return;
+        if (objectKeyList.isEmpty()) {
+            return;
+        }
         ArrayList<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
         for (String objectKey : objectKeyList) {
             keys.add(new DeleteObjectsRequest.KeyVersion(shortsLocationPrefixHead + objectKey + shortsLocationPrefixTail));

--- a/src/main/java/com/nexters/phochak/client/impl/NCPStorageClient.java
+++ b/src/main/java/com/nexters/phochak/client/impl/NCPStorageClient.java
@@ -59,6 +59,7 @@ public class NCPStorageClient implements StorageBucketClient {
 
     @Override
     public void removeShortsObject(List<String> objectKeyList) {
+        if (objectKeyList.isEmpty()) return;
         ArrayList<DeleteObjectsRequest.KeyVersion> keys = new ArrayList<>();
         for (String objectKey : objectKeyList) {
             keys.add(new DeleteObjectsRequest.KeyVersion(shortsLocationPrefixHead + objectKey + shortsLocationPrefixTail));


### PR DESCRIPTION
❗️ 이슈 번호
close #138 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
유저가 올린 게시글이 하나도 없을 경우,
유저 탈퇴에서 삭제할 object가 없어서 S3 오류가 났었군요.

일반적인 테스트에서 SDK는 정상적으로 작동해서 생각보다 찾기 어려운 버그였습니다.. ㅋㅋㅋ


추가로 해당 transaction에서 제외하기 위해 다음 처리를 했습니다.
- object 삭제 비동기처리
- 롤백에 대비하여, 탈퇴 마지막 프로세스로 object 삭제 적용

🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
