### PR TITLE
fix: 좋아요한 게시글의 닉네임이 조회한 사람의 닉네임이 표시되는 버그 수정 

### DIFF
--- a/src/main/java/com/nexters/phochak/repository/impl/LikesCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/LikesCustomRepositoryImpl.java
@@ -76,7 +76,7 @@ public class LikesCustomRepositoryImpl implements LikesCustomRepository {
                 .groupBy(post.id)
                 .transform(groupBy(post.id).as(
                         new QPostFetchDto(post.id,
-                                new QPostFetchDto_PostUserInformation(likes.user.id, likes.user.nickname, likes.user.profileImgUrl),
+                                new QPostFetchDto_PostUserInformation(post.user.id, post.user.nickname, post.user.profileImgUrl),
                                 new QPostFetchDto_PostShortsInformation(shorts.id, shorts.shortsStateEnum, shorts.shortsUrl, shorts.thumbnailUrl),
                                 likes.post.view, likes.post.postCategory, likes.post.isBlind)
                 ));


### PR DESCRIPTION
❗️ 이슈 번호
close #155 


📝 구현 내용
- 포착한 게시물의 닉네임 버그 수정!



🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
