### PR TITLE
feat: 유저가 신고한 게시글은 더 이상 본인에게 보이지 않음

### DIFF
--- a/src/main/java/com/nexters/phochak/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/domain/Post.java
@@ -47,6 +47,9 @@ public class Post extends BaseTime {
     @JoinColumn(name = "SHORTS_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Shorts shorts;
 
+    @OneToMany(mappedBy = "post")
+    private List<ReportPost> reportPost;
+
     @Column(nullable = false)
     @ColumnDefault("0")
     private Long view;

--- a/src/main/java/com/nexters/phochak/domain/ReportPost.java
+++ b/src/main/java/com/nexters/phochak/domain/ReportPost.java
@@ -13,7 +13,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
-import javax.persistence.OneToOne;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 @Getter
@@ -26,11 +26,11 @@ public class ReportPost extends BaseTime {
     @Column(name="REPORT_ID")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private User reporter;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "POST_ID", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Post post;
 

--- a/src/main/java/com/nexters/phochak/domain/ReportPost.java
+++ b/src/main/java/com/nexters/phochak/domain/ReportPost.java
@@ -18,7 +18,9 @@ import javax.persistence.Table;
 
 @Getter
 @Entity
-@Table(indexes = {@Index(name = "idx01_unique_report_post", columnList = "USER_ID, POST_ID", unique = true)})
+@Table(indexes =
+        {@Index(name = "idx01_unique_report_post", columnList = "USER_ID, POST_ID", unique = true),
+        @Index(name = "idx02_report_post", columnList = "USER_ID")})
 public class ReportPost extends BaseTime {
 
     @Id

--- a/src/main/java/com/nexters/phochak/domain/ReportPost.java
+++ b/src/main/java/com/nexters/phochak/domain/ReportPost.java
@@ -18,9 +18,7 @@ import javax.persistence.Table;
 
 @Getter
 @Entity
-@Table(indexes =
-        {@Index(name = "idx01_unique_report_post", columnList = "USER_ID, POST_ID", unique = true),
-        @Index(name = "idx02_report_post", columnList = "USER_ID")})
+@Table(indexes = {@Index(name = "idx01_unique_report_post", columnList = "USER_ID, POST_ID", unique = true)})
 public class ReportPost extends BaseTime {
 
     @Id

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -45,7 +45,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                                 .select(reportPost.post.id)
                                 .from(reportPost)
                                 .where(reportPost.reporter.id.eq(command.getUserId())
-                ))) // 본인이 신고헌 게시글 제거
+                ))) // 본인이 신고한 게시글 제거
                 .where(post.shorts.shortsStateEnum.eq(ShortsStateEnum.OK)) // shorts의 인코딩이 완료된 게시글
                 .limit(command.getPageSize())
                 .orderBy(orderByPostSortOption(command.getSortOption())) // 커서 정렬 조건

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -12,7 +12,9 @@ import com.nexters.phochak.specification.ShortsStateEnum;
 import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.nexters.phochak.domain.QReportPost.reportPost;
 import static com.querydsl.core.group.GroupBy.groupBy;
 
 @Slf4j
@@ -37,6 +40,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .join(post.shorts)
                 .where(filterByCursor(command)) // 커서 기반 페이징
                 .where(getFilterExpression(command)) // 내가 업로드한 게시글
+                .where(post.id.notIn(
+                        JPAExpressions
+                                .select(reportPost.post.id)
+                                .from(reportPost)
+                                .where(reportPost.reporter.id.eq(command.getUserId())
+                ))) // 본인이 신고헌 게시글 제거
                 .where(post.shorts.shortsStateEnum.eq(ShortsStateEnum.OK)) // shorts의 인코딩이 완료된 게시글
                 .limit(command.getPageSize())
                 .orderBy(orderByPostSortOption(command.getSortOption())) // 커서 정렬 조건
@@ -54,7 +63,6 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .map(resultMap::get)
                 .collect(Collectors.toList());
     }
-
 
     private static BooleanExpression getFilterExpression(PostFetchCommand command) {
         if (command.hasUploadedFilter()) {

--- a/src/main/resources/sql/V20220526_001_신고관련인덱스추가.sql
+++ b/src/main/resources/sql/V20220526_001_신고관련인덱스추가.sql
@@ -1,2 +1,0 @@
--- 게시글
-create index idx02_report_post on report_post (user_id);

--- a/src/main/resources/sql/V20220526_001_신고관련인덱스추가.sql
+++ b/src/main/resources/sql/V20220526_001_신고관련인덱스추가.sql
@@ -1,0 +1,2 @@
+-- 게시글
+create index idx02_report_post on report_post (user_id);


### PR DESCRIPTION
❗️ 이슈 번호
close #157 

일단 신속한 iOS 앱 심사를 위해서 merge하겠습니다!!!

📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
유저가 신고한 게시글은 더이상 본인에게 보이지 않도록 쿼리를 수정했습니다.


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

### in 절에 서브쿼리 사용

```
.where(post.id.notIn(
        JPAExpressions
                .select(reportPost.post.id)
                .from(reportPost)
                .where(reportPost.reporter.id.eq(command.getUserId())
))) // 본인이 신고헌 게시글 제거
```


### user_id 인덱스 추가 후 실행계획 확인

In 절에 서브쿼리 사용했습니다. left join 활용하는 것에 비해 조금의 성능 걱정은 있었습니다만..

처음에는 일단 유저가 신고한 게시글인지 빠르게 탐색하기 위해서 `user_id` 에 인덱스를 걸었었습니다.

그런데 실제로 실행계획을 돌려보니..

![스크린샷 2023-05-26 오전 11 28 40](https://github.com/Nexters/phochak-server/assets/76773202/fc454d9b-aeab-4d64-aa60-5f7c9ffa9a1d)

제가 이번에 추가한 `idx02_report_post` 를 후보로만 올려놓고, 실제로는 기존에 걸려있던 `idx01_unique_report_post` 키를 활용하더군요.

어! 왜 이렇지!!! 라고 샤워를 하며 곰곰히 생각을 했는데, 생각해보니 기존 unique index table에 `(user_id, post_id)`가 있다는 깨달음을 얻었고, 실제로 호다닥 확인해보니 `Extra: Using index` 가 적혀있더군요.

인덱스에 모든 값이 올라가있어서, 실제로는 disk I/O가 일어나지 않는 커버링 인덱스로 실행되었네요.
다시 생각해보면, 만약 커버링 인덱스가 없더라도 `(user_id, post_id)` 복합키에서 user_id가 선행 컬럼이라서, 단독 index를 거는 것과 차이가 없었을 겁니다.

케케.. 싱글벙글 기분이 좋습니다. ㅎㅎ


💡 참고 자료
(없다면 지워도 됩니다!)

Real MySQL

![스크린샷 2023-05-26 오전 11 36 33](https://github.com/Nexters/phochak-server/assets/76773202/80dadb0e-0cee-4390-aa9f-7bc8e9925bc6)
