### PR TITLE
feat: 유저 무시하기 API 구현

### DIFF
--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -327,3 +327,148 @@ include::{snippets}/user/modify/nickname/response-fields.adoc[]
 |닉네임이 중복되었습니다
 |저장하려는 시점에 닉네임 중복 발생, 수정하여 재시도 필요
 |===
+
+=== 유저 무시하기
+특정 유저의 게시글을 더 이상 볼 수 없게 무시합니다.
+
+* 무시하기: A유저가 B 유저를 무시(차단)
+* 차단하기: 시스템에 의한 글로벌 차단
+
+==== 요청
+HTTP Example
+
+include::{snippets}/user/ignore/POST/http-request.adoc[]
+
+Request Headers
+
+include::{snippets}/user/ignore/POST/request-headers.adoc[]
+
+Path Parameters
+
+include::{snippets}/user/ignore/POST/path-parameters.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/user/ignore/POST/http-response.adoc[]
+
+Response Parameters
+
+include::{snippets}/user/ignore/POST/response-fields.adoc[]
+
+**유저 무시하기 API 응답코드**
+[cols="2,10,7"]
+|===
+|응답코드
+|응답메시지
+|설명
+
+|P000
+|정상 처리
+|유저 차단 성공
+
+|P200
+|요청 값의 형식이 올바르지 않습니다
+|파라미터 형식 오류
+
+|P206
+|요청 필수 값이 존재하지 않습니다
+|필수 파라미터 누락
+
+|P302
+|이미 무시하기한 유저입니다
+|이미 무시하기한 유저의 경우
+|===
+
+=== 유저 무시하기 해제
+유저 무시하기를 해제합니다.
+
+==== 요청
+HTTP Example
+
+include::{snippets}/user/ignore/DELETE/http-request.adoc[]
+
+Request Headers
+
+include::{snippets}/user/ignore/DELETE/request-headers.adoc[]
+
+Path Parameters
+
+include::{snippets}/user/ignore/DELETE/path-parameters.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/user/ignore/DELETE/http-response.adoc[]
+
+Response Parameters
+
+include::{snippets}/user/ignore/DELETE/response-fields.adoc[]
+
+**유저 무시하기 API 응답코드**
+[cols="2,10,7"]
+|===
+|응답코드
+|응답메시지
+|설명
+
+|P000
+|정상 처리
+|유저 차단 성공
+
+|P200
+|요청 값의 형식이 올바르지 않습니다
+|파라미터 형식 오류
+
+|P206
+|요청 필수 값이 존재하지 않습니다
+|필수 파라미터 누락
+
+|P303
+|무시하기 하지 않았던 유저입니다
+|무시하기 하지 않았던 유저의 경우
+|===
+
+=== 무시한 유저 리스트 조회
+무시하기 처리했던 유저의 목록을 조회합니다
+
+==== 요청
+HTTP Example
+
+include::{snippets}/user/ignore/GET/http-request.adoc[]
+
+Request Headers
+
+include::{snippets}/user/ignore/GET/request-headers.adoc[]
+
+==== 응답
+Response HTTP Example
+
+*정상*
+include::{snippets}/user/ignore/GET/http-response.adoc[]
+
+Response Parameters
+
+include::{snippets}/user/ignore/GET/response-fields.adoc[]
+
+**유저 무시하기 API 응답코드**
+[cols="2,10,7"]
+|===
+|응답코드
+|응답메시지
+|설명
+
+|P000
+|정상 처리
+|유저 차단 성공
+
+|P200
+|요청 값의 형식이 올바르지 않습니다
+|파라미터 형식 오류
+
+|P206
+|요청 필수 값이 존재하지 않습니다
+|필수 파라미터 누락
+|===

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -18,6 +18,7 @@ import com.nexters.phochak.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -92,6 +93,14 @@ public class UserController {
         Long userId = UserContext.CONTEXT.get();
         jwtTokenService.logout(withdrawRequestDto.getRefreshToken());
         userService.withdraw(userId);
+        return new CommonResponse<>();
+    }
+
+    @Auth
+    @PostMapping("/{userId}/ignore")
+    public CommonResponse<Void> ignoreUser(@PathVariable(value = "userId") Long pageOwnerId) {
+        Long me = UserContext.CONTEXT.get();
+        userService.ignoreUser(me, pageOwnerId);
         return new CommonResponse<>();
     }
 }

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.controller;
 
 import com.nexters.phochak.auth.UserContext;
 import com.nexters.phochak.auth.annotation.Auth;
+import com.nexters.phochak.dto.response.IgnoredUserResponseDto;
 import com.nexters.phochak.dto.request.LoginRequestDto;
 import com.nexters.phochak.dto.request.LogoutRequestDto;
 import com.nexters.phochak.dto.request.NicknameModifyRequestDto;
@@ -29,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -97,18 +99,25 @@ public class UserController {
     }
 
     @Auth
-    @PostMapping("/{userId}/ignore")
-    public CommonResponse<Void> ignoreUser(@PathVariable(value = "userId") Long pageOwnerId) {
+    @PostMapping("/ignore/{pageOwnerId}")
+    public CommonResponse<Void> ignoreUser(@PathVariable(value = "pageOwnerId") Long pageOwnerId) {
         Long me = UserContext.CONTEXT.get();
         userService.ignoreUser(me, pageOwnerId);
         return new CommonResponse<>();
     }
 
     @Auth
-    @DeleteMapping("/{userId}/ignore")
-    public CommonResponse<Void> cancelIgnoreUser(@PathVariable(value = "userId") Long pageOwnerId) {
+    @DeleteMapping("/ignore/{pageOwnerId}")
+    public CommonResponse<Void> cancelIgnoreUser(@PathVariable(value = "pageOwnerId") Long pageOwnerId) {
         Long me = UserContext.CONTEXT.get();
         userService.cancelIgnoreUser(me, pageOwnerId);
         return new CommonResponse<>();
+    }
+
+    @Auth
+    @GetMapping("/ignore")
+    public CommonResponse<List<IgnoredUserResponseDto>> getIgnoreUser(@PathVariable(value = "pageOwnerId") Long pageOwnerId) {
+        Long me = UserContext.CONTEXT.get();
+        return new CommonResponse<>(userService.getIgnoreUserList(me));
     }
 }

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -99,18 +99,18 @@ public class UserController {
     }
 
     @Auth
-    @PostMapping("/ignore/{pageOwnerId}")
-    public CommonResponse<Void> ignoreUser(@PathVariable(value = "pageOwnerId") Long pageOwnerId) {
+    @PostMapping("/ignore/{ignoredUserId}")
+    public CommonResponse<Void> ignoreUser(@PathVariable(value = "ignoredUserId") Long ignoredUserId) {
         Long me = UserContext.CONTEXT.get();
-        userService.ignoreUser(me, pageOwnerId);
+        userService.ignoreUser(me, ignoredUserId);
         return new CommonResponse<>();
     }
 
     @Auth
-    @DeleteMapping("/ignore/{pageOwnerId}")
-    public CommonResponse<Void> cancelIgnoreUser(@PathVariable(value = "pageOwnerId") Long pageOwnerId) {
+    @DeleteMapping("/ignore/{ignoredUserId}")
+    public CommonResponse<Void> cancelIgnoreUser(@PathVariable(value = "ignoredUserId") Long ignoredUserId) {
         Long me = UserContext.CONTEXT.get();
-        userService.cancelIgnoreUser(me, pageOwnerId);
+        userService.cancelIgnoreUser(me, ignoredUserId);
         return new CommonResponse<>();
     }
 

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -103,4 +103,12 @@ public class UserController {
         userService.ignoreUser(me, pageOwnerId);
         return new CommonResponse<>();
     }
+
+    @Auth
+    @DeleteMapping("/{userId}/ignore")
+    public CommonResponse<Void> cancelIgnoreUser(@PathVariable(value = "userId") Long pageOwnerId) {
+        Long me = UserContext.CONTEXT.get();
+        userService.cancelIgnoreUser(me, pageOwnerId);
+        return new CommonResponse<>();
+    }
 }

--- a/src/main/java/com/nexters/phochak/controller/UserController.java
+++ b/src/main/java/com/nexters/phochak/controller/UserController.java
@@ -116,7 +116,7 @@ public class UserController {
 
     @Auth
     @GetMapping("/ignore")
-    public CommonResponse<List<IgnoredUserResponseDto>> getIgnoreUser(@PathVariable(value = "pageOwnerId") Long pageOwnerId) {
+    public CommonResponse<List<IgnoredUserResponseDto>> getIgnoreUser() {
         Long me = UserContext.CONTEXT.get();
         return new CommonResponse<>(userService.getIgnoreUserList(me));
     }

--- a/src/main/java/com/nexters/phochak/domain/IgnoredUser.java
+++ b/src/main/java/com/nexters/phochak/domain/IgnoredUser.java
@@ -1,0 +1,44 @@
+package com.nexters.phochak.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapsId;
+import javax.persistence.Table;
+
+@Getter
+@Entity
+@Table(indexes = {@Index(name="idx02_unique_ignored_user", columnList = "USER_ID, IGNORED_USER_ID", unique = true)})
+public class IgnoredUser {
+
+    @Id
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name="USER_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="IGNORED_USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User ignoredUser;
+
+    @Builder
+    public IgnoredUser(User user, User ignoredUser) {
+        this.user = user;
+        this.ignoredUser = ignoredUser;
+    }
+
+    public IgnoredUser() {
+    }
+}

--- a/src/main/java/com/nexters/phochak/domain/IgnoredUsers.java
+++ b/src/main/java/com/nexters/phochak/domain/IgnoredUsers.java
@@ -3,9 +3,7 @@ package com.nexters.phochak.domain;
 import lombok.Builder;
 import lombok.Getter;
 
-import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
-import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.ForeignKey;
@@ -19,7 +17,7 @@ import javax.persistence.Table;
 @Getter
 @Entity
 @Table(indexes = {@Index(name="idx02_unique_ignored_user", columnList = "USER_ID, IGNORED_USER_ID", unique = true)})
-public class IgnoredUser {
+public class IgnoredUsers {
 
     @Id
     private Long id;
@@ -34,11 +32,11 @@ public class IgnoredUser {
     private User ignoredUser;
 
     @Builder
-    public IgnoredUser(User user, User ignoredUser) {
+    public IgnoredUsers(User user, User ignoredUser) {
         this.user = user;
         this.ignoredUser = ignoredUser;
     }
 
-    public IgnoredUser() {
+    public IgnoredUsers() {
     }
 }

--- a/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
@@ -1,6 +1,6 @@
 package com.nexters.phochak.dto.response;
 
-import com.nexters.phochak.domain.IgnoredUser;
+import com.nexters.phochak.domain.IgnoredUsers;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,7 +17,7 @@ public class IgnoredUserResponseDto {
     private String nickname;
     private String profileImageUrl;
 
-    public static IgnoredUserResponseDto of(IgnoredUser ignoredUser) {
+    public static IgnoredUserResponseDto of(IgnoredUsers ignoredUser) {
         return new IgnoredUserResponseDto(
                 ignoredUser.getIgnoredUser().getId(),
                 ignoredUser.getIgnoredUser().getNickname(),
@@ -25,7 +25,7 @@ public class IgnoredUserResponseDto {
             );
     }
 
-    public static List<IgnoredUserResponseDto> of(List<IgnoredUser> ignoredUserList) {
+    public static List<IgnoredUserResponseDto> of(List<IgnoredUsers> ignoredUserList) {
         return ignoredUserList.stream()
                 .map(IgnoredUserResponseDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
@@ -1,0 +1,33 @@
+package com.nexters.phochak.dto.response;
+
+import com.nexters.phochak.domain.IgnoredUser;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class IgnoredUserResponseDto {
+
+    private Long id;
+    private String nickname;
+    private String profileImageUrl;
+
+    public static IgnoredUserResponseDto of(IgnoredUser ignoredUser) {
+        return new IgnoredUserResponseDto(
+                ignoredUser.getIgnoredUser().getId(),
+                ignoredUser.getIgnoredUser().getNickname(),
+                ignoredUser.getIgnoredUser().getProfileImgUrl()
+            );
+    }
+
+    public static List<IgnoredUserResponseDto> of(List<IgnoredUser> ignoredUserList) {
+        return ignoredUserList.stream()
+                .map(IgnoredUserResponseDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.dto.response;
 
 import com.nexters.phochak.domain.IgnoredUsers;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,11 +12,12 @@ import java.util.stream.Collectors;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class IgnoredUserResponseDto {
 
     private Long id;
     private String nickname;
-    private String profileImageUrl;
+    private String profileImgUrl;
 
     public static IgnoredUserResponseDto of(IgnoredUsers ignoredUser) {
         return new IgnoredUserResponseDto(

--- a/src/main/java/com/nexters/phochak/exception/ResCode.java
+++ b/src/main/java/com/nexters/phochak/exception/ResCode.java
@@ -19,8 +19,8 @@ public enum ResCode {
     //P3xx: 유저 예외
     NOT_FOUND_USER("P300", "존재하지 않는 유저입니다"),
     DUPLICATED_NICKNAME("P301", "닉네임이 중복되었습니다"),
-    ALREADY_IGNORED_USER("P302", "이미 차단된 유저입니다"),
-    NOT_IGNORED_USER("P303", "차단하지 않았던 유저입니다"),
+    ALREADY_IGNORED_USER("P302", "이미 무시하기한 유저입니다"),
+    NOT_IGNORED_USER("P303", "무시하기 하지 않았던 유저입니다"),
 
     //P4xx: 게시글 예외
     NOT_FOUND_POST("P400", "존재하지 않는 게시글입니다"),

--- a/src/main/java/com/nexters/phochak/exception/ResCode.java
+++ b/src/main/java/com/nexters/phochak/exception/ResCode.java
@@ -19,6 +19,8 @@ public enum ResCode {
     //P3xx: 유저 예외
     NOT_FOUND_USER("P300", "존재하지 않는 유저입니다"),
     DUPLICATED_NICKNAME("P301", "닉네임이 중복되었습니다"),
+    ALREADY_IGNORED_USER("P302", "이미 차단된 유저입니다"),
+    NOT_IGNORED_USER("P303", "차단하지 않았던 유저입니다"),
 
     //P4xx: 게시글 예외
     NOT_FOUND_POST("P400", "존재하지 않는 게시글입니다"),

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -11,8 +11,8 @@ import java.util.List;
 public interface IgnoredUserRepository extends JpaRepository<IgnoredUsers, Long> {
 
     @Modifying
-    @Query("delete from IgnoredUsers i where i.user.id = :me and i.ignoredUser.id = :pageOwnerId")
-    void deleteIgnore(@Param("me")Long me, @Param("pageOwnerId")Long pageOwnerId);
+    @Query("delete from IgnoredUsers i where i.user.id = :me and i.ignoredUser.id = :ignoredUserId")
+    void deleteIgnore(@Param("me")Long me, @Param("pageOwnerId")Long ignoredUserId);
 
     @Modifying
     @Query("select i from IgnoredUsers i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -2,6 +2,13 @@ package com.nexters.phochak.repository;
 
 import com.nexters.phochak.domain.IgnoredUser;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IgnoredUserRepository extends JpaRepository<IgnoredUser, Long> {
+
+    @Modifying
+    @Query("delete from IgnoredUser i where i.user.id = :me and i.ignoredUser.id = :pageOwnerId")
+    void deleteIgnore(@Param("me")Long me, @Param("pageOwnerId")Long pageOwnerId);
 }

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -12,7 +12,7 @@ public interface IgnoredUserRepository extends JpaRepository<IgnoredUsers, Long>
 
     @Modifying
     @Query("delete from IgnoredUsers i where i.user.id = :me and i.ignoredUser.id = :ignoredUserId")
-    void deleteIgnore(@Param("me")Long me, @Param("pageOwnerId")Long ignoredUserId);
+    void deleteIgnore(@Param("me")Long me, @Param("ignoredUserId")Long ignoredUserId);
 
     @Modifying
     @Query("select i from IgnoredUsers i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -1,6 +1,6 @@
 package com.nexters.phochak.repository;
 
-import com.nexters.phochak.domain.IgnoredUser;
+import com.nexters.phochak.domain.IgnoredUsers;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,13 +8,13 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface IgnoredUserRepository extends JpaRepository<IgnoredUser, Long> {
+public interface IgnoredUserRepository extends JpaRepository<IgnoredUsers, Long> {
 
     @Modifying
-    @Query("delete from IgnoredUser i where i.user.id = :me and i.ignoredUser.id = :pageOwnerId")
+    @Query("delete from IgnoredUsers i where i.user.id = :me and i.ignoredUser.id = :pageOwnerId")
     void deleteIgnore(@Param("me")Long me, @Param("pageOwnerId")Long pageOwnerId);
 
     @Modifying
-    @Query("select i from IgnoredUser i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")
-    List<IgnoredUser> getIgnoreUserListByUserId(Long me);
+    @Query("select i from IgnoredUsers i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")
+    List<IgnoredUsers> getIgnoreUserListByUserId(Long me);
 }

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -1,0 +1,7 @@
+package com.nexters.phochak.repository;
+
+import com.nexters.phochak.domain.IgnoredUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IgnoredUserRepository extends JpaRepository<IgnoredUser, Long> {
+}

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -6,9 +6,15 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface IgnoredUserRepository extends JpaRepository<IgnoredUser, Long> {
 
     @Modifying
     @Query("delete from IgnoredUser i where i.user.id = :me and i.ignoredUser.id = :pageOwnerId")
     void deleteIgnore(@Param("me")Long me, @Param("pageOwnerId")Long pageOwnerId);
+
+    @Modifying
+    @Query("select i from IgnoredUser i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")
+    List<IgnoredUser> getIgnoreUserListByUserId(Long me);
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -12,7 +12,6 @@ import com.nexters.phochak.specification.ShortsStateEnum;
 import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -46,8 +45,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                         JPAExpressions
                                 .select(ignoredUsers.ignoredUser.id)
                                 .from(ignoredUsers)
-                                .where(reportPost.reporter.id.eq(command.getUserId())
-                ))) //본인이 ignore한 게시글 제거
+                                .where(reportPost.reporter.id.eq(command.getUserId()))
+                )) //본인이 ignore한 게시글 제거
                 .where(post.id.notIn(
                         JPAExpressions
                                 .select(reportPost.post.id)

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.nexters.phochak.domain.QIgnoredUsers.ignoredUsers;
 import static com.nexters.phochak.domain.QReportPost.reportPost;
+import static com.nexters.phochak.domain.QUser.user;
 import static com.querydsl.core.group.GroupBy.groupBy;
 
 @Slf4j
@@ -40,6 +42,12 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .join(post.shorts)
                 .where(filterByCursor(command)) // 커서 기반 페이징
                 .where(getFilterExpression(command)) // 내가 업로드한 게시글
+                .where(user.id.notIn(
+                        JPAExpressions
+                                .select(ignoredUsers.ignoredUser.id)
+                                .from(ignoredUsers)
+                                .where(reportPost.reporter.id.eq(command.getUserId())
+                ))) //본인이 ignore한 게시글 제거
                 .where(post.id.notIn(
                         JPAExpressions
                                 .select(reportPost.post.id)

--- a/src/main/java/com/nexters/phochak/service/UserService.java
+++ b/src/main/java/com/nexters/phochak/service/UserService.java
@@ -1,7 +1,10 @@
 package com.nexters.phochak.service;
 
+import com.nexters.phochak.dto.response.IgnoredUserResponseDto;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
 import com.nexters.phochak.dto.response.UserInfoResponseDto;
+
+import java.util.List;
 
 public interface UserService {
 
@@ -44,4 +47,6 @@ public interface UserService {
     void ignoreUser(Long me, Long pageOwnerId);
 
     void cancelIgnoreUser(Long me, Long pageOwnerId);
+
+    List<IgnoredUserResponseDto> getIgnoreUserList(Long me);
 }

--- a/src/main/java/com/nexters/phochak/service/UserService.java
+++ b/src/main/java/com/nexters/phochak/service/UserService.java
@@ -44,9 +44,9 @@ public interface UserService {
 
     void withdraw(Long userId);
 
-    void ignoreUser(Long me, Long pageOwnerId);
+    void ignoreUser(Long me, Long ignoredUserId);
 
-    void cancelIgnoreUser(Long me, Long pageOwnerId);
+    void cancelIgnoreUser(Long me, Long ignoredUserId);
 
     List<IgnoredUserResponseDto> getIgnoreUserList(Long me);
 }

--- a/src/main/java/com/nexters/phochak/service/UserService.java
+++ b/src/main/java/com/nexters/phochak/service/UserService.java
@@ -40,4 +40,8 @@ public interface UserService {
     UserInfoResponseDto getInfo(Long pageOwnerId, Long userId);
 
     void withdraw(Long userId);
+
+    void ignoreUser(Long me, Long pageOwnerId);
+
+    void cancelIgnoreUser(Long me, Long pageOwnerId);
 }

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.nexters.phochak.service.impl;
 import com.nexters.phochak.auth.UserContext;
 import com.nexters.phochak.domain.IgnoredUser;
 import com.nexters.phochak.domain.User;
+import com.nexters.phochak.dto.response.IgnoredUserResponseDto;
 import com.nexters.phochak.dto.OAuthUserInformation;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
 import com.nexters.phochak.dto.response.UserInfoResponseDto;
@@ -20,6 +21,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -110,6 +112,13 @@ public class UserServiceImpl implements UserService {
     @Override
     public void cancelIgnoreUser(Long me, Long pageOwnerId) {
         ignoredUserRepository.deleteIgnore(me, pageOwnerId);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public List<IgnoredUserResponseDto> getIgnoreUserList(Long me) {
+        List<IgnoredUser> ignoreUserListByUserId = ignoredUserRepository.getIgnoreUserListByUserId(me);
+        return IgnoredUserResponseDto.of(ignoreUserListByUserId);
     }
 
     private boolean isDuplicatedNickname(String nickname) {

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -95,9 +95,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void ignoreUser(Long me, Long pageOwnerId) {
+    public void ignoreUser(Long me, Long ignoredUserId) {
         User user = userRepository.getReferenceById(me);
-        User pageOwner = userRepository.findById(pageOwnerId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
+        User pageOwner = userRepository.findById(ignoredUserId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
         try {
             ignoredUserRepository.save(IgnoredUsers.builder()
                     .user(user)
@@ -110,8 +110,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void cancelIgnoreUser(Long me, Long pageOwnerId) {
-        ignoredUserRepository.deleteIgnore(me, pageOwnerId);
+    public void cancelIgnoreUser(Long me, Long ignoredUserId) {
+        ignoredUserRepository.deleteIgnore(me, ignoredUserId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -107,6 +107,11 @@ public class UserServiceImpl implements UserService {
         }
     }
 
+    @Override
+    public void cancelIgnoreUser(Long me, Long pageOwnerId) {
+        ignoredUserRepository.deleteIgnore(me, pageOwnerId);
+    }
+
     private boolean isDuplicatedNickname(String nickname) {
         return userRepository.existsByNickname(nickname);
     }

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -1,7 +1,7 @@
 package com.nexters.phochak.service.impl;
 
 import com.nexters.phochak.auth.UserContext;
-import com.nexters.phochak.domain.IgnoredUser;
+import com.nexters.phochak.domain.IgnoredUsers;
 import com.nexters.phochak.domain.User;
 import com.nexters.phochak.dto.response.IgnoredUserResponseDto;
 import com.nexters.phochak.dto.OAuthUserInformation;
@@ -99,7 +99,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.getReferenceById(me);
         User pageOwner = userRepository.findById(pageOwnerId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
         try {
-            ignoredUserRepository.save(IgnoredUser.builder()
+            ignoredUserRepository.save(IgnoredUsers.builder()
                     .user(user)
                     .ignoredUser(pageOwner)
                     .build());
@@ -117,7 +117,7 @@ public class UserServiceImpl implements UserService {
     @Transactional(readOnly = true)
     @Override
     public List<IgnoredUserResponseDto> getIgnoreUserList(Long me) {
-        List<IgnoredUser> ignoreUserListByUserId = ignoredUserRepository.getIgnoreUserListByUserId(me);
+        List<IgnoredUsers> ignoreUserListByUserId = ignoredUserRepository.getIgnoreUserListByUserId(me);
         return IgnoredUserResponseDto.of(ignoreUserListByUserId);
     }
 

--- a/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
@@ -2,11 +2,18 @@ package com.nexters.phochak.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.phochak.docs.RestDocs;
+import com.nexters.phochak.domain.Likes;
+import com.nexters.phochak.domain.Post;
+import com.nexters.phochak.domain.Shorts;
+import com.nexters.phochak.domain.User;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
 import com.nexters.phochak.dto.response.UserInfoResponseDto;
 import com.nexters.phochak.dto.response.JwtResponseDto;
+import com.nexters.phochak.exception.PhochakException;
+import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.service.JwtTokenService;
 import com.nexters.phochak.service.UserService;
+import com.nexters.phochak.specification.PostCategoryEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,6 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.nexters.phochak.auth.aspect.AuthAspect.AUTHORIZATION_HEADER;
+import static com.nexters.phochak.exception.ResCode.OK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -31,6 +39,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -41,6 +51,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -235,5 +246,66 @@ class UserControllerTest extends RestDocs {
                                 fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크")
                         )
                 ));
+    }
+
+    @Test
+    @DisplayName("유저 API - 유저 무시하기")
+    void ignoreUser() throws Exception {
+        //given
+        doNothing().when(userService).ignoreUser(any(), any());
+        //when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders
+                                .post("/v1/user/ignore/{ignoredUserId}", 10)
+                                .header(AUTHORIZATION_HEADER, "access token")
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("user/ignore",
+                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("ignoredUserId").description("(필수) 무시하기 하려는 유저의 id 설정")
+                        ),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) JWT Access Token")
+                        ),
+                        responseFields(
+                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("유저 API - 유저 무시하기 취소")
+    void cancelIgnoreUser() throws Exception {
+        //given
+        doNothing().when(userService).cancelIgnoreUser(any(), any());
+        //when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders
+                                .delete("/v1/user/ignore/{ignoredUserId}", 10)
+                                .header(AUTHORIZATION_HEADER, "access token")
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("user/ignore",
+                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("ignoredUserId").description("(필수) 무시하기 했던 유저의 id 설정")
+                        ),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) JWT Access Token")
+                        ),
+                        responseFields(
+                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답")
+                        )
+                ));
+
     }
 }

--- a/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import com.nexters.phochak.domain.Likes;
 import com.nexters.phochak.domain.Post;
 import com.nexters.phochak.domain.Shorts;
 import com.nexters.phochak.domain.User;
+import com.nexters.phochak.dto.response.IgnoredUserResponseDto;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
 import com.nexters.phochak.dto.response.UserInfoResponseDto;
 import com.nexters.phochak.dto.response.JwtResponseDto;
@@ -27,7 +28,9 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static com.nexters.phochak.auth.aspect.AuthAspect.AUTHORIZATION_HEADER;
@@ -260,7 +263,7 @@ class UserControllerTest extends RestDocs {
                                 .header(AUTHORIZATION_HEADER, "access token")
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andDo(document("user/ignore",
+                .andDo(document("user/ignore/POST",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -290,7 +293,7 @@ class UserControllerTest extends RestDocs {
                                 .header(AUTHORIZATION_HEADER, "access token")
                                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andDo(document("user/ignore",
+                .andDo(document("user/ignore/DELETE",
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
@@ -304,6 +307,42 @@ class UserControllerTest extends RestDocs {
                                 fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
                                 fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
                                 fieldWithPath("data").type(JsonFieldType.NULL).description("응답")
+                        )
+                ));
+
+    }
+
+    @Test
+    @DisplayName("유저 API - 무시하기한 유저 목록 조회")
+    void getIgnoreUser() throws Exception {
+        //given
+        List<IgnoredUserResponseDto> response = new ArrayList<>();
+        response.add(IgnoredUserResponseDto.builder()
+                .id(10L)
+                .nickname("nickname10")
+                .profileImgUrl("profile_image_url10")
+                .build());
+        when(userService.getIgnoreUserList(any())).thenReturn(response);
+        //when, then
+        mockMvc.perform(
+                        RestDocumentationRequestBuilders
+                                .get("/v1/user/ignore", 10)
+                                .header(AUTHORIZATION_HEADER, "access token")
+                                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andDo(document("user/ignore/GET",
+                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(
+                                headerWithName(AUTHORIZATION_HEADER)
+                                        .description("(필수) JWT Access Token")
+                        ),
+                        responseFields(
+                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("무시한 유저 id"),
+                                fieldWithPath("data[].nickname").type(JsonFieldType.STRING).description("무시한 유저 닉네임"),
+                                fieldWithPath("data[].profileImgUrl").type(JsonFieldType.STRING).description("무시한 유저 프로필 이미지 링크")
                         )
                 ));
 

--- a/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
@@ -2,19 +2,12 @@ package com.nexters.phochak.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.phochak.docs.RestDocs;
-import com.nexters.phochak.domain.Likes;
-import com.nexters.phochak.domain.Post;
-import com.nexters.phochak.domain.Shorts;
-import com.nexters.phochak.domain.User;
 import com.nexters.phochak.dto.response.IgnoredUserResponseDto;
 import com.nexters.phochak.dto.response.UserCheckResponseDto;
 import com.nexters.phochak.dto.response.UserInfoResponseDto;
 import com.nexters.phochak.dto.response.JwtResponseDto;
-import com.nexters.phochak.exception.PhochakException;
-import com.nexters.phochak.exception.ResCode;
 import com.nexters.phochak.service.JwtTokenService;
 import com.nexters.phochak.service.UserService;
-import com.nexters.phochak.specification.PostCategoryEnum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 
 import static com.nexters.phochak.auth.aspect.AuthAspect.AUTHORIZATION_HEADER;
-import static com.nexters.phochak.exception.ResCode.OK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
@@ -42,8 +34,6 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -54,7 +44,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
❗️ 이슈 번호
close #159 

📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

심사를 위해 빠른 merge 합니다!

- 특정 유저를 차단하는 API
- 차단했던 유저의 차단을 해제하는 API
- 본인이 차단한 유저의 목록을 불러오는 API
- 차단한 유저의 게시글이 더이상 피드에 표시되지 않도록 구현

문서화 확인 완료 !
![스크린샷 2023-06-09 오후 6 36 56](https://github.com/Nexters/phochak-server/assets/76773202/46a6a6d1-5a8e-4bf8-a179-8e43c6fefd92)

메인피드 및 검색 결과에 무시하기 적용된 유저의 게시글이 나오지 않도록 표시
~~진짜 이 쿼리 어떡하지~~
```
  .where(user.id.notIn(
          JPAExpressions
                  .select(ignoredUsers.ignoredUser.id)
                  .from(ignoredUsers)
                  .where(reportPost.reporter.id.eq(command.getUserId()))
  )) //본인이 ignore한 게시글 제거
```
### 다음 연속 작업 TODO
1. 다른 유저의 프로필과 게시글을 을 볼 수 있는 유저페이지 구현
2. 카테고리(여행/맛집/카페) 필터 구현 - 해시태그 검색과 함께 쓸 수 있도록 구현해야 함.

💡 참고 자료
(없다면 지워도 됩니다!)
