### PR TITLE
fix: postfilter에 NONE 기본값 생성

### DIFF
--- a/src/main/java/com/nexters/phochak/controller/PostController.java
+++ b/src/main/java/com/nexters/phochak/controller/PostController.java
@@ -63,7 +63,8 @@ public class PostController {
 
     @Auth
     @GetMapping("/list")
-    public CommonPageResponse<PostPageResponseDto> getPostList(@Valid CustomCursor customCursor, PostFilter filter) {
+    public CommonPageResponse<PostPageResponseDto> getPostList(@Valid CustomCursor customCursor,
+                                                               @RequestParam(required = false, defaultValue = "NONE") PostFilter filter) {
         List<PostPageResponseDto> nextCursorPage = postService.getNextCursorPage(customCursor, filter);
         if (nextCursorPage.size() < customCursor.getPageSize()) {
             return new CommonPageResponse<>(nextCursorPage, true);

--- a/src/main/java/com/nexters/phochak/dto/request/PostFilter.java
+++ b/src/main/java/com/nexters/phochak/dto/request/PostFilter.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 public enum PostFilter {
     UPLOADED, // 내가 업로드한 동영상
     LIKED, // 내가 좋아요한 동영상
-    SEARCH; // 게시글 검색
+    SEARCH, // 게시글 검색
+    NONE // 필터 없음 (메인 피드)
 }

--- a/src/main/java/com/nexters/phochak/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/PostServiceImpl.java
@@ -122,6 +122,7 @@ public class PostServiceImpl implements PostService {
             case LIKED:
                 return getNextCursorPage(command.getUserId(), likesService.findLikedPostsByCommand(command));
             case UPLOADED:
+            case NONE:
             default:
                 return getNextCursorPage(command.getUserId(), postRepository.findNextPageByCommmand(command));
         }


### PR DESCRIPTION
❗️ 이슈 번호
close #163 


📝 구현 내용

search 적용하면서 다음 swich case에서 command.getFilter() 일 때 NPE가 발생하였습니다.
enum에 NONE 값 추가하고, default값 지정하였습니다.
![스크린샷 2023-06-09 오후 6 59 41](https://github.com/Nexters/phochak-server/assets/76773202/bd3f7f07-2200-48d9-a011-c103d29984be)
![스크린샷 2023-06-09 오후 7 00 21](https://github.com/Nexters/phochak-server/assets/76773202/dc231b39-38db-4e2a-a589-392d12f3a925)


요청 확인 완료
![스크린샷 2023-06-09 오후 6 57 23](https://github.com/Nexters/phochak-server/assets/76773202/f171e560-7fd6-44a4-b258-1d7215ad6c88)

(가능한 한 자세히 작성해 주시면 감사하겠습니다!)



🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
