### PR TITLE
refactor: 다른 유저의 유저 페이지를 볼 수 있도록 변경

### DIFF
--- a/src/main/java/com/nexters/phochak/controller/PostController.java
+++ b/src/main/java/com/nexters/phochak/controller/PostController.java
@@ -63,9 +63,8 @@ public class PostController {
 
     @Auth
     @GetMapping("/list")
-    public CommonPageResponse<PostPageResponseDto> getPostList(@Valid CustomCursor customCursor,
-                                                               @RequestParam(required = false, defaultValue = "NONE") PostFilter filter) {
-        List<PostPageResponseDto> nextCursorPage = postService.getNextCursorPage(customCursor, filter);
+    public CommonPageResponse<PostPageResponseDto> getPostList(@Valid CustomCursor customCursor) {
+        List<PostPageResponseDto> nextCursorPage = postService.getNextCursorPage(customCursor);
         if (nextCursorPage.size() < customCursor.getPageSize()) {
             return new CommonPageResponse<>(nextCursorPage, true);
         }

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -3,6 +3,8 @@ package com.nexters.phochak.domain;
 import com.nexters.phochak.specification.OAuthProviderEnum;
 import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Type;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,6 +39,11 @@ public class User extends BaseTime {
     private String nickname;
 
     private String profileImgUrl;
+
+    @Column(nullable = false, columnDefinition = "CHAR(1) DEFAULT 'N'")
+    @Type(type = "yes_no")
+    private boolean isBlocked = false;
+
     private LocalDateTime leaveDate;
 
     public User() {
@@ -61,5 +68,9 @@ public class User extends BaseTime {
         this.provider = null;
         this.profileImgUrl = null;
         this.leaveDate = LocalDateTime.now();
+    }
+
+    public void block() {
+        this.isBlocked = true;
     }
 }

--- a/src/main/java/com/nexters/phochak/domain/User.java
+++ b/src/main/java/com/nexters/phochak/domain/User.java
@@ -42,7 +42,7 @@ public class User extends BaseTime {
 
     @Column(nullable = false, columnDefinition = "CHAR(1) DEFAULT 'N'")
     @Type(type = "yes_no")
-    private boolean isBlocked = false;
+    private Boolean isBlocked = false;
 
     private LocalDateTime leaveDate;
 

--- a/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
@@ -19,6 +19,7 @@ public class PostFetchCommand {
     private final PostSortOption sortOption;
     private final Integer sortValue;
     private final PostFilter filter;
+    private final Long targetUserId;
     private final String searchHashtag;
 
     public static PostFetchCommand of(CustomCursor customCursor, long userId) {
@@ -29,6 +30,7 @@ public class PostFetchCommand {
                 .sortOption(customCursor.getSortOption())
                 .sortValue(customCursor.getSortValue())
                 .filter(customCursor.getFilter())
+                .targetUserId(customCursor.getTargetUserId())
                 .searchHashtag(null)
                 .build();
     }
@@ -41,6 +43,7 @@ public class PostFetchCommand {
                 .sortOption(customCursor.getSortOption())
                 .sortValue(customCursor.getSortValue())
                 .filter(PostFilter.SEARCH)
+                .targetUserId(customCursor.getTargetUserId())
                 .searchHashtag(hashtag)
                 .build();
     }

--- a/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
@@ -21,26 +21,26 @@ public class PostFetchCommand {
     private final PostFilter filter;
     private final String searchHashtag;
 
-    public static PostFetchCommand of(CustomCursor customCursor, PostFilter filter, long userId) {
+    public static PostFetchCommand of(CustomCursor customCursor, long userId) {
         return PostFetchCommand.builder()
                 .userId(userId)
                 .lastId(customCursor.getLastId())
                 .pageSize(customCursor.getPageSize())
                 .sortOption(customCursor.getSortOption())
                 .sortValue(customCursor.getSortValue())
-                .filter(filter)
+                .filter(customCursor.getFilter())
                 .searchHashtag(null)
                 .build();
     }
 
-    public static PostFetchCommand of(CustomCursor customCursor, PostFilter filter, long userId, String hashtag) {
+    public static PostFetchCommand of(CustomCursor customCursor, long userId, String hashtag) {
         return PostFetchCommand.builder()
                 .userId(userId)
                 .lastId(customCursor.getLastId())
                 .pageSize(customCursor.getPageSize())
                 .sortOption(customCursor.getSortOption())
                 .sortValue(customCursor.getSortValue())
-                .filter(filter)
+                .filter(PostFilter.SEARCH)
                 .searchHashtag(hashtag)
                 .build();
     }

--- a/src/main/java/com/nexters/phochak/dto/request/CustomCursor.java
+++ b/src/main/java/com/nexters/phochak/dto/request/CustomCursor.java
@@ -19,13 +19,15 @@ public class CustomCursor {
     private Integer pageSize;
     private PostSortOption sortOption;
     private Integer sortValue;
+    private PostFilter filter;
 
     @Builder
-    public CustomCursor(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue) {
+    public CustomCursor(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter) {
         this.lastId = lastId;
         this.pageSize = Objects.isNull(pageSize) ? DEFAULT_PAGE_SIZE : pageSize;
         this.sortOption = Objects.isNull(sortOption) ? PostSortOption.LATEST : sortOption;
         this.sortValue = sortValue;
+        this.filter = Objects.isNull(filter) ? PostFilter.NONE : filter;
 
         // 첫 요청 시 lastId, sortValue는 null로, sortOption만 받음
         if (Objects.isNull(lastId) && Objects.isNull(this.sortValue)) {

--- a/src/main/java/com/nexters/phochak/dto/request/CustomCursor.java
+++ b/src/main/java/com/nexters/phochak/dto/request/CustomCursor.java
@@ -20,14 +20,16 @@ public class CustomCursor {
     private PostSortOption sortOption;
     private Integer sortValue;
     private PostFilter filter;
+    private Long targetUserId;
 
     @Builder
-    public CustomCursor(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter) {
+    public CustomCursor(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter, Long targetUserId) {
         this.lastId = lastId;
         this.pageSize = Objects.isNull(pageSize) ? DEFAULT_PAGE_SIZE : pageSize;
         this.sortOption = Objects.isNull(sortOption) ? PostSortOption.LATEST : sortOption;
         this.sortValue = sortValue;
         this.filter = Objects.isNull(filter) ? PostFilter.NONE : filter;
+        this.targetUserId = targetUserId;
 
         // 첫 요청 시 lastId, sortValue는 null로, sortOption만 받음
         if (Objects.isNull(lastId) && Objects.isNull(this.sortValue)) {

--- a/src/main/java/com/nexters/phochak/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/UserInfoResponseDto.java
@@ -14,13 +14,17 @@ public class UserInfoResponseDto {
     private String nickname;
     private String profileImgUrl;
     private Boolean isMyPage;
+    private Boolean isIgnored;
+    private Boolean isBlocked;
 
-    public static UserInfoResponseDto of(User user, Boolean isMyPage) {
+    public static UserInfoResponseDto of(User user, Boolean isMyPage, Boolean isIgnored) {
         return UserInfoResponseDto.builder()
-                .isMyPage(isMyPage)
                 .id(user.getId())
                 .nickname(user.getNickname())
                 .profileImgUrl(user.getProfileImgUrl())
+                .isMyPage(isMyPage)
+                .isIgnored(isIgnored)
+                .isBlocked(user.getIsBlocked())
                 .build();
     }
 }

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -17,4 +17,6 @@ public interface IgnoredUserRepository extends JpaRepository<IgnoredUsers, Long>
     @Modifying
     @Query("select i from IgnoredUsers i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")
     List<IgnoredUsers> getIgnoreUserListByUserId(Long me);
+
+    Boolean existsByUserIdAndIgnoredUserId(Long userId, Long pageOwnerId);
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -73,7 +73,11 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
     private static BooleanExpression getFilterExpression(PostFetchCommand command) {
         if (command.hasUploadedFilter()) {
-            return post.user.id.eq(command.getUserId());
+            if(command.getTargetUserId() == null) {
+                return post.user.id.eq(command.getUserId());
+            } else {
+                return post.user.id.eq(command.getTargetUserId());
+            }
         }
         return null;
     }

--- a/src/main/java/com/nexters/phochak/service/PostService.java
+++ b/src/main/java/com/nexters/phochak/service/PostService.java
@@ -22,7 +22,7 @@ public interface PostService {
      * @param customCursor
      * @return
      */
-    List<PostPageResponseDto> getNextCursorPage(CustomCursor customCursor, PostFilter filter);
+    List<PostPageResponseDto> getNextCursorPage(CustomCursor customCursor);
 
     void update(Long userId, Long postId, PostUpdateRequestDto postUpdateRequestDto);
 

--- a/src/main/java/com/nexters/phochak/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/PostServiceImpl.java
@@ -97,10 +97,10 @@ public class PostServiceImpl implements PostService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<PostPageResponseDto> getNextCursorPage(CustomCursor customCursor, PostFilter filter) {
+    public List<PostPageResponseDto> getNextCursorPage(CustomCursor customCursor) {
         final Long userId = UserContext.CONTEXT.get();
 
-        PostFetchCommand command = PostFetchCommand.of(customCursor, filter, userId);
+        PostFetchCommand command = PostFetchCommand.of(customCursor, userId);
 
         return createPostPageResponseDto(command);
     }
@@ -110,7 +110,7 @@ public class PostServiceImpl implements PostService {
     public List<PostPageResponseDto> getNextCursorPage(CustomCursor customCursor, String hashtag) {
         final Long userId = UserContext.CONTEXT.get();
 
-        PostFetchCommand command = PostFetchCommand.of(customCursor, PostFilter.SEARCH, userId, hashtag);
+        PostFetchCommand command = PostFetchCommand.of(customCursor, userId, hashtag);
 
         return createPostPageResponseDto(command);
     }

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -79,12 +79,14 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserInfoResponseDto getInfo(Long pageOwnerId, Long userId) {
         User pageOwner;
+        Boolean isIgnored = false;
         if (pageOwnerId == null) {
             pageOwner = userRepository.findById(userId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
         } else {
             pageOwner = userRepository.findById(pageOwnerId).orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
+            isIgnored = ignoredUserRepository.existsByUserIdAndIgnoredUserId(userId, pageOwnerId);
         }
-        return UserInfoResponseDto.of(pageOwner, pageOwner.getId().equals(userId));
+        return UserInfoResponseDto.of(pageOwner, pageOwner.getId().equals(userId), isIgnored);
     }
 
     @Override

--- a/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/nexters/phochak/service/impl/UserServiceImpl.java
@@ -77,6 +77,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UserInfoResponseDto getInfo(Long pageOwnerId, Long userId) {
         User pageOwner;
         Boolean isIgnored = false;

--- a/src/main/resources/sql/V20230609_001_무시테이블추가.sql
+++ b/src/main/resources/sql/V20230609_001_무시테이블추가.sql
@@ -1,0 +1,9 @@
+-- 유저가 다른 유저를 무시하는 테이블
+create table ignored_users (
+   user_id bigint not null,
+   ignored_user_id bigint,
+   primary key (user_id)
+) engine=InnoDB;
+
+-- multiple unique 인덱스 추가
+alter table ignored_users add constraint idx02_unique_ignored_user unique (user_id, ignored_user_id);

--- a/src/main/resources/sql/V20230610_001_유저컬럼에_차단여부추가.sql
+++ b/src/main/resources/sql/V20230610_001_유저컬럼에_차단여부추가.sql
@@ -1,0 +1,1 @@
+alter table `user` add column is_blocked CHAR(1) DEFAULT 'N' not null;

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -135,12 +135,13 @@ class PostControllerTest extends RestDocs {
     void getPostList_initial() throws Exception {
         CustomCursor customCursor = CustomCursor.builder()
                 .sortOption(PostSortOption.LATEST)
+                .filter(PostFilter.NONE)
                 .pageSize(2)
                 .build();
 
         List<PostPageResponseDto> result = List.of(post2, post1);
 
-        when(postService.getNextCursorPage(any(), (PostFilter) any())).thenReturn(result);
+        when(postService.getNextCursorPage(any())).thenReturn(result);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders
@@ -188,6 +189,7 @@ class PostControllerTest extends RestDocs {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(3)
                 .sortOption(PostSortOption.LIKE)
+                .filter(PostFilter.NONE)
                 .lastId(20L)
                 .sortValue(75)
                 .build();
@@ -208,7 +210,7 @@ class PostControllerTest extends RestDocs {
 
         List<PostPageResponseDto> result = List.of(post3, post2, post1);
 
-        when(postService.getNextCursorPage(any(), (PostFilter) any())).thenReturn(result);
+        when(postService.getNextCursorPage(any())).thenReturn(result);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders
@@ -261,6 +263,7 @@ class PostControllerTest extends RestDocs {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(5)
                 .sortOption(PostSortOption.VIEW)
+                .filter(PostFilter.NONE)
                 .lastId(3L)
                 .sortValue(100)
                 .build();
@@ -281,7 +284,7 @@ class PostControllerTest extends RestDocs {
 
         List<PostPageResponseDto> result = List.of(post3, post2, post1);
 
-        when(postService.getNextCursorPage(any(), (PostFilter) any())).thenReturn(result);
+        when(postService.getNextCursorPage(any())).thenReturn(result);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders
@@ -334,11 +337,10 @@ class PostControllerTest extends RestDocs {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(3)
                 .sortOption(PostSortOption.LIKE)
+                .filter(PostFilter.UPLOADED)
                 .lastId(20L)
                 .sortValue(75)
                 .build();
-
-        PostFilter postFilter = PostFilter.UPLOADED;
 
         List<String> hashtags = List.of("내가", "업로드");
 
@@ -363,7 +365,7 @@ class PostControllerTest extends RestDocs {
         List<PostPageResponseDto> result = List.of(post3);
 
 
-        when(postService.getNextCursorPage(any(), (PostFilter) any())).thenReturn(result);
+        when(postService.getNextCursorPage(any())).thenReturn(result);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders
@@ -372,7 +374,7 @@ class PostControllerTest extends RestDocs {
                                 .param("lastId", String.valueOf(customCursor.getLastId()))
                                 .param("sortOption", customCursor.getSortOption().name())
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
-                                .param("filter", postFilter.name())
+                                .param("filter", customCursor.getFilter().name())
                                 .header(AUTHORIZATION_HEADER, "access token")
                 )
                 .andExpect(status().isOk())
@@ -418,11 +420,10 @@ class PostControllerTest extends RestDocs {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(3)
                 .sortOption(PostSortOption.LIKE)
+                .filter(PostFilter.LIKED)
                 .lastId(20L)
                 .sortValue(75)
                 .build();
-
-        PostFilter postFilter = PostFilter.LIKED;
 
         List<String> hashtags = List.of("좋아요한", "게시글");
 
@@ -447,7 +448,7 @@ class PostControllerTest extends RestDocs {
         List<PostPageResponseDto> result = List.of(post3, post1);
 
 
-        when(postService.getNextCursorPage(any(), (PostFilter) any())).thenReturn(result);
+        when(postService.getNextCursorPage(any())).thenReturn(result);
 
         mockMvc.perform(
                         RestDocumentationRequestBuilders
@@ -456,7 +457,7 @@ class PostControllerTest extends RestDocs {
                                 .param("lastId", String.valueOf(customCursor.getLastId()))
                                 .param("sortOption", customCursor.getSortOption().name())
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
-                                .param("filter", postFilter.name())
+                                .param("filter", customCursor.getFilter().name())
                                 .header(AUTHORIZATION_HEADER, "access token")
                 )
                 .andExpect(status().isOk())

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -332,17 +332,18 @@ class PostControllerTest extends RestDocs {
     }
 
     @Test
-    @DisplayName("포스트 목록 조회 API - 내가 업로드한 영상")
+    @DisplayName("포스트 목록 조회 API - 나 또는 다른 유저가 업로드한 영상")
     void getPostList_uploaded() throws Exception {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(3)
                 .sortOption(PostSortOption.LIKE)
                 .filter(PostFilter.UPLOADED)
+                .targetUserId(10L)
                 .lastId(20L)
                 .sortValue(75)
                 .build();
 
-        List<String> hashtags = List.of("내가", "업로드");
+        List<String> hashtags = List.of("누군가가", "업로드");
 
         PostUserInformation newUser = PostUserInformation.builder()
                 .id(4L)
@@ -375,6 +376,7 @@ class PostControllerTest extends RestDocs {
                                 .param("sortOption", customCursor.getSortOption().name())
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
                                 .param("filter", customCursor.getFilter().name())
+                                .param("targetUserId", String.valueOf(customCursor.getTargetUserId()))
                                 .header(AUTHORIZATION_HEADER, "access token")
                 )
                 .andExpect(status().isOk())
@@ -386,7 +388,8 @@ class PostControllerTest extends RestDocs {
                                 parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)"),
                                 parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
                                 parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                                parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                                parameterWithName("targetUserId").description("(선택) 조회할 페이지의 유저 id (본인의 페이지라면 생략 가능)")
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)

--- a/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/UserControllerTest.java
@@ -171,10 +171,12 @@ class UserControllerTest extends RestDocs {
     @DisplayName("유저 API - 다른 유저 페이지 정보 조회하기")
     void getInfoOtherUserPage() throws Exception {
         UserInfoResponseDto response = UserInfoResponseDto.builder()
-                .isMyPage(false)
                 .id(1L)
                 .nickname("nickname")
                 .profileImgUrl("profile image url")
+                .isMyPage(false)
+                .isIgnored(true)
+                .isBlocked(false)
                 .build();
 
         given(userService.getInfo(any(),any())).willReturn(response);
@@ -197,10 +199,12 @@ class UserControllerTest extends RestDocs {
                         responseFields(
                                 fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
                                 fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data.isMyPage").type(JsonFieldType.BOOLEAN).description("접속자가 해당 페이지의 주인인지 확인"),
                                 fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저 식별값(id)"),
                                 fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
-                                fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크")
+                                fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
+                                fieldWithPath("data.isMyPage").type(JsonFieldType.BOOLEAN).description("접속자가 해당 페이지의 주인인지 확인"),
+                                fieldWithPath("data.isBlocked").type(JsonFieldType.BOOLEAN).description("해당 유저 차단 여부"),
+                                fieldWithPath("data.isIgnored").type(JsonFieldType.BOOLEAN).description("해당 유저 무시 여부")
                         )
                 ));
     }
@@ -209,10 +213,12 @@ class UserControllerTest extends RestDocs {
     @DisplayName("유저 API - 본인 유저 페이지 정보 조회하기")
     void getInfoMyPage() throws Exception {
         UserInfoResponseDto response = UserInfoResponseDto.builder()
-                .isMyPage(true)
                 .id(1L)
                 .nickname("nickname")
                 .profileImgUrl("profile image url")
+                .isMyPage(true)
+                .isIgnored(false)
+                .isBlocked(false)
                 .build();
 
         given(userService.getInfo(any(),any())).willReturn(response);
@@ -232,10 +238,12 @@ class UserControllerTest extends RestDocs {
                         responseFields(
                                 fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
                                 fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data.isMyPage").type(JsonFieldType.BOOLEAN).description("접속자가 해당 페이지의 주인인지 확인"),
                                 fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저 식별값(id)"),
                                 fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
-                                fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크")
+                                fieldWithPath("data.profileImgUrl").type(JsonFieldType.STRING).description("프로필 이미지 링크"),
+                                fieldWithPath("data.isMyPage").type(JsonFieldType.BOOLEAN).description("접속자가 해당 페이지의 주인인지 확인 (항상 true)"),
+                                fieldWithPath("data.isBlocked").type(JsonFieldType.BOOLEAN).description("해당 유저 차단 여부 (항상 false)"),
+                                fieldWithPath("data.isIgnored").type(JsonFieldType.BOOLEAN).description("해당 유저 무시 여부 (항상 false)")
                         )
                 ));
     }


### PR DESCRIPTION
❗️ 이슈 번호
close #165 

심사 관련 내용이라, 직접 api 요청 테스트 돌려보고 빠르게 Merge 합니다.

📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

- 기존 유저 피드 조회에서, 다른 유저의 피드도 조회할 수 있도록 변경
- 기존 유저 정보 불러오기 api에서, 다른 유저의 정보도 조회할 수 있도록 변경
- isMyPage 필드 추가: 본인의 페이지인지 확인 가능하게 구현
- isBlocked 필드 추가: 시스템에서 전역적으로 차단된 유저인지 확인
- isIgnored 필드 추가: 접속한 유저가 해당 유저를 무시하기한 유저인지 확인

---

다른 유저 조회 잘 작동. 무시된 유저인지 확인하는 필드도 확인 완료.
![스크린샷 2023-06-10 오전 8 37 44](https://github.com/Nexters/phochak-server/assets/76773202/a176131a-9a3c-4fb3-97bd-03d278f257d8)

기존 본인 업로드 잘 작동.
![스크린샷 2023-06-10 오전 7 46 25](https://github.com/Nexters/phochak-server/assets/76773202/bb2246bd-db68-4078-84ba-64324437c5d8)

다른 유저 업로드 게시글 잘 작동.
![스크린샷 2023-06-10 오전 7 46 53](https://github.com/Nexters/phochak-server/assets/76773202/b2df973f-3250-49c5-b502-bad853142db0)



🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

1. 피드 요청에서, PostFIlter를 cursor 쿼리 파라미터 하나에 합쳤습니다.
2. 정렬 쿼리를 이참에 삭제할까 하다가, 혹시 또 기획 변경될지 모르니 일단 그냥 냅뒀습니다!


💡 참고 자료
(없다면 지워도 됩니다!)
