### PR TITLE
feat: 해시태그 검색에 카테고리 검색 추가

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -132,9 +132,13 @@ Response Parameters
 
 include::{snippets}/post/list/liked/response-fields.adoc[]
 
-=== 해시태그 검색 결과 게시글 목록
+=== 해시태그 및 카테고리 검색 결과 게시글 목록
 
 새롭게 명시된 내용 외에는, 위의 `게시글 불러오기` API와 동일합니다.
+
+검색어 해시태그와 완전 일치하는 해시태그를 포함한 경우 검색됩니다.
+
+해시태그 / 카테고리 / 해시태그+카테고리 조합으로 검색 가능합니다.
 
 HTTP Example
 

--- a/src/docs/asciidoc/user.adoc
+++ b/src/docs/asciidoc/user.adoc
@@ -207,7 +207,7 @@ include::{snippets}/user/withdraw/response-fields.adoc[]
 |===
 
 === 유저페이지 유저 정보 조회
-현재 로그인된 유저의 정보를 가져온다.
+현재 로그인된 유저 또는 다른 유저의 정보를 불러온다.
 
 ==== 요청
 HTTP Example

--- a/src/main/java/com/nexters/phochak/controller/PostController.java
+++ b/src/main/java/com/nexters/phochak/controller/PostController.java
@@ -73,7 +73,7 @@ public class PostController {
 
     @Auth
     @GetMapping("/list/search")
-    public CommonPageResponse<PostPageResponseDto> getPostListBySearchHashtag(@Valid CustomCursor customCursor, @RequestParam String hashtag) {
+    public CommonPageResponse<PostPageResponseDto> getPostListBySearchHashtag(@Valid CustomCursor customCursor, @RequestParam(required = false) String hashtag) {
         List<PostPageResponseDto> nextCursorPage = postService.getNextCursorPage(customCursor, hashtag);
         if (nextCursorPage.size() < customCursor.getPageSize()) {
             return new CommonPageResponse<>(nextCursorPage, true);

--- a/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
+++ b/src/main/java/com/nexters/phochak/dto/PostFetchCommand.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.dto;
 
 import com.nexters.phochak.dto.request.CustomCursor;
 import com.nexters.phochak.dto.request.PostFilter;
+import com.nexters.phochak.specification.PostCategoryEnum;
 import com.nexters.phochak.specification.PostSortOption;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,6 +22,7 @@ public class PostFetchCommand {
     private final PostFilter filter;
     private final Long targetUserId;
     private final String searchHashtag;
+    private final PostCategoryEnum category;
 
     public static PostFetchCommand of(CustomCursor customCursor, long userId) {
         return PostFetchCommand.builder()
@@ -32,6 +34,7 @@ public class PostFetchCommand {
                 .filter(customCursor.getFilter())
                 .targetUserId(customCursor.getTargetUserId())
                 .searchHashtag(null)
+                .category(null)
                 .build();
     }
 
@@ -45,6 +48,7 @@ public class PostFetchCommand {
                 .filter(PostFilter.SEARCH)
                 .targetUserId(customCursor.getTargetUserId())
                 .searchHashtag(hashtag)
+                .category(customCursor.getCategory())
                 .build();
     }
 

--- a/src/main/java/com/nexters/phochak/dto/request/CustomCursor.java
+++ b/src/main/java/com/nexters/phochak/dto/request/CustomCursor.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.dto.request;
 
 import com.nexters.phochak.exception.PhochakException;
 import com.nexters.phochak.exception.ResCode;
+import com.nexters.phochak.specification.PostCategoryEnum;
 import com.nexters.phochak.specification.PostSortOption;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,15 +22,17 @@ public class CustomCursor {
     private Integer sortValue;
     private PostFilter filter;
     private Long targetUserId;
+    private PostCategoryEnum category;
 
     @Builder
-    public CustomCursor(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter, Long targetUserId) {
+    public CustomCursor(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter, Long targetUserId, PostCategoryEnum category) {
         this.lastId = lastId;
         this.pageSize = Objects.isNull(pageSize) ? DEFAULT_PAGE_SIZE : pageSize;
         this.sortOption = Objects.isNull(sortOption) ? PostSortOption.LATEST : sortOption;
         this.sortValue = sortValue;
         this.filter = Objects.isNull(filter) ? PostFilter.NONE : filter;
         this.targetUserId = targetUserId;
+        this.category = category;
 
         // 첫 요청 시 lastId, sortValue는 null로, sortOption만 받음
         if (Objects.isNull(lastId) && Objects.isNull(this.sortValue)) {

--- a/src/main/java/com/nexters/phochak/repository/HashtagRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/HashtagRepository.java
@@ -19,7 +19,7 @@ public interface HashtagRepository extends JpaRepository<Hashtag, Long>, Hashtag
     @Modifying
     void deleteAllByPostIdIn(@Param("postIdList") List<Long> postIdList);
 
-    @Query("select h.tag from Hashtag h where h.tag like :hashtag% order by length(h.tag)")
+    @Query("select distinct h.tag from Hashtag h where h.tag like :hashtag% order by length(h.tag)")
     List<String> findByHashtagStartsWith(@Param("hashtag") String hashtag, Pageable pageable);
 
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/HashtagCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/HashtagCustomRepositoryImpl.java
@@ -50,7 +50,7 @@ public class HashtagCustomRepositoryImpl implements HashtagCustomRepository {
                 .join(post.shorts)
                 .where(filterByCursor(command)) // 커서 기반 페이징
                 .where(filterByCategory(command.getCategory()))
-                .where(post.hashtags.any().tag.eq(command.getSearchHashtag())) // 해당 해시태그를 가진 게시글
+                .where(searchByHashtag(command.getSearchHashtag()))
                 .where(post.user.id.notIn(
                         JPAExpressions
                                 .select(ignoredUsers.ignoredUser.id)
@@ -78,6 +78,13 @@ public class HashtagCustomRepositoryImpl implements HashtagCustomRepository {
         return resultMap.keySet().stream()
                 .map(resultMap::get)
                 .collect(Collectors.toList());
+    }
+
+    private BooleanExpression searchByHashtag(String searchHashtag) {
+        if(searchHashtag == null) {
+            return null;
+        }
+        return post.hashtags.any().tag.eq(searchHashtag);
     }
 
     private BooleanExpression filterByCategory(PostCategoryEnum category) {

--- a/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
+++ b/src/test/java/com/nexters/phochak/controller/PostControllerTest.java
@@ -506,6 +506,7 @@ class PostControllerTest extends RestDocs {
         CustomCursor customCursor = CustomCursor.builder()
                 .pageSize(3)
                 .lastId(20L)
+                .category(PostCategoryEnum.CAFE)
                 .build();
 
         List<String> hashtags = List.of("해시태그1", "해시태그2");
@@ -539,6 +540,7 @@ class PostControllerTest extends RestDocs {
                                 .param("lastId", String.valueOf(customCursor.getLastId()))
                                 .param("pageSize", String.valueOf(customCursor.getPageSize()))
                                 .param("hashtag", String.valueOf(hashtags.get(1)))
+                                .param("category", String.valueOf(customCursor.getCategory()))
                                 .header(AUTHORIZATION_HEADER, "access token")
                 )
                 .andExpect(status().isOk())
@@ -546,9 +548,10 @@ class PostControllerTest extends RestDocs {
                         preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestParameters(
-                                parameterWithName("hashtag").description("(필수) 검색할 해시태그").optional(),
-                                parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional()
+                                parameterWithName("lastId").description("(선택) 마지막으로 받은 게시글 id"),
+                                parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
+                                parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional(),
+                                parameterWithName("category").description("(선택) 게시글 카테고리 ex) CAFE").optional()
                         ),
                         requestHeaders(
                                 headerWithName(AUTHORIZATION_HEADER)


### PR DESCRIPTION
❗️ 이슈 번호
close #166 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

- 해시태그 검색과 함께 카테고리 검색이 가능하게 적용했습니다.
  - 해시태그 / 카테고리 / 해시태그+카테고리 조합으로 검색 가능합니다.
- 해시태그 autocomplete에 distinct 적용했습니다.
![스크린샷 2023-06-10 오전 9 54 47](https://github.com/Nexters/phochak-server/assets/76773202/4c4a7747-a927-4d10-a1b4-8a4db0e63784)
![스크린샷 2023-06-10 오전 9 54 55](https://github.com/Nexters/phochak-server/assets/76773202/3baacf3f-11ca-4f33-bad3-17128ea554c0)


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

음. 메인피드/해시태그검색/유저페이지피드 가 사실상 거의 동일한 동적 쿼리라서, 병합해도 좋을 듯 합니다.


💡 참고 자료
(없다면 지워도 됩니다!)
