### PR TITLE
refactor: ignored user 엔티티의 복합키 재적용

### DIFF
--- a/src/main/java/com/nexters/phochak/domain/IgnoredUsers.java
+++ b/src/main/java/com/nexters/phochak/domain/IgnoredUsers.java
@@ -3,38 +3,19 @@ package com.nexters.phochak.domain;
 import lombok.Builder;
 import lombok.Getter;
 
-import javax.persistence.ConstraintMode;
+import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.ForeignKey;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.MapsId;
-import javax.persistence.Table;
 
 @Getter
 @Entity
-@Table(indexes = {@Index(name="idx02_unique_ignored_user", columnList = "USER_ID, IGNORED_USER_ID", unique = true)})
 public class IgnoredUsers {
 
-    @Id
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name="USER_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="IGNORED_USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
-    private User ignoredUser;
+    @EmbeddedId
+    private IgnoredUsersRelation ignoredUsersRelation;
 
     @Builder
-    public IgnoredUsers(User user, User ignoredUser) {
-        this.user = user;
-        this.ignoredUser = ignoredUser;
+    public IgnoredUsers(IgnoredUsersRelation ignoredUsersRelation) {
+        this.ignoredUsersRelation = ignoredUsersRelation;
     }
 
     public IgnoredUsers() {

--- a/src/main/java/com/nexters/phochak/domain/IgnoredUsersRelation.java
+++ b/src/main/java/com/nexters/phochak/domain/IgnoredUsersRelation.java
@@ -1,0 +1,32 @@
+package com.nexters.phochak.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.ConstraintMode;
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.io.Serializable;
+
+@Getter
+@Embeddable
+@NoArgsConstructor
+public class IgnoredUsersRelation implements Serializable {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="USER_ID", referencedColumnName = "USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="IGNORED_USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    private User ignoredUser;
+
+    @Builder
+    public IgnoredUsersRelation(User user, User ignoredUser) {
+        this.user = user;
+        this.ignoredUser = ignoredUser;
+    }
+}

--- a/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
+++ b/src/main/java/com/nexters/phochak/dto/response/IgnoredUserResponseDto.java
@@ -21,9 +21,9 @@ public class IgnoredUserResponseDto {
 
     public static IgnoredUserResponseDto of(IgnoredUsers ignoredUser) {
         return new IgnoredUserResponseDto(
-                ignoredUser.getIgnoredUser().getId(),
-                ignoredUser.getIgnoredUser().getNickname(),
-                ignoredUser.getIgnoredUser().getProfileImgUrl()
+                ignoredUser.getIgnoredUsersRelation().getIgnoredUser().getId(),
+                ignoredUser.getIgnoredUsersRelation().getIgnoredUser().getNickname(),
+                ignoredUser.getIgnoredUsersRelation().getIgnoredUser().getProfileImgUrl()
             );
     }
 

--- a/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
+++ b/src/main/java/com/nexters/phochak/repository/IgnoredUserRepository.java
@@ -1,6 +1,7 @@
 package com.nexters.phochak.repository;
 
 import com.nexters.phochak.domain.IgnoredUsers;
+import com.nexters.phochak.domain.IgnoredUsersRelation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,15 +9,19 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface IgnoredUserRepository extends JpaRepository<IgnoredUsers, Long> {
+public interface IgnoredUserRepository extends JpaRepository<IgnoredUsers, IgnoredUsersRelation> {
 
     @Modifying
-    @Query("delete from IgnoredUsers i where i.user.id = :me and i.ignoredUser.id = :ignoredUserId")
+    @Query("delete from IgnoredUsers i " +
+            "where i.ignoredUsersRelation.user.id = :me " +
+            "and i.ignoredUsersRelation.ignoredUser.id = :ignoredUserId")
     void deleteIgnore(@Param("me")Long me, @Param("ignoredUserId")Long ignoredUserId);
 
     @Modifying
-    @Query("select i from IgnoredUsers i left join fetch User u on i.ignoredUser.id = u.id where i.user.id = :me")
-    List<IgnoredUsers> getIgnoreUserListByUserId(Long me);
+    @Query("select i from IgnoredUsers i " +
+            "left join fetch User u on i.ignoredUsersRelation.ignoredUser.id = u.id " +
+            "where i.ignoredUsersRelation.user.id = :me")
+    List<IgnoredUsers> getIgnoreUserListByUserId(@Param("me") Long me);
 
-    Boolean existsByUserIdAndIgnoredUserId(Long userId, Long pageOwnerId);
+    Boolean existsByIgnoredUsersRelation(IgnoredUsersRelation ignoredUsersRelation);
 }

--- a/src/main/java/com/nexters/phochak/repository/impl/HashtagCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/HashtagCustomRepositoryImpl.java
@@ -12,7 +12,6 @@ import com.nexters.phochak.dto.QPostFetchDto_PostUserInformation;
 import com.nexters.phochak.repository.HashtagCustomRepository;
 import com.nexters.phochak.specification.PostCategoryEnum;
 import com.nexters.phochak.specification.ShortsStateEnum;
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,7 +23,6 @@ import java.util.stream.Collectors;
 
 import static com.nexters.phochak.domain.QIgnoredUsers.ignoredUsers;
 import static com.nexters.phochak.domain.QReportPost.reportPost;
-import static com.nexters.phochak.domain.QUser.user;
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 
@@ -53,9 +51,9 @@ public class HashtagCustomRepositoryImpl implements HashtagCustomRepository {
                 .where(searchByHashtag(command.getSearchHashtag()))
                 .where(post.user.id.notIn(
                         JPAExpressions
-                                .select(ignoredUsers.ignoredUser.id)
+                                .select(ignoredUsers.ignoredUsersRelation.ignoredUser.id)
                                 .from(ignoredUsers)
-                                .where(ignoredUsers.ignoredUser.id.eq(command.getUserId()))
+                                .where(ignoredUsers.ignoredUsersRelation.user.id.eq(command.getUserId()))
                 )) //본인이 ignore한 게시글 제거
                 .where(post.id.notIn(
                         JPAExpressions

--- a/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/repository/impl/PostCustomRepositoryImpl.java
@@ -24,7 +24,6 @@ import java.util.stream.Collectors;
 
 import static com.nexters.phochak.domain.QIgnoredUsers.ignoredUsers;
 import static com.nexters.phochak.domain.QReportPost.reportPost;
-import static com.nexters.phochak.domain.QUser.user;
 import static com.querydsl.core.group.GroupBy.groupBy;
 
 @Slf4j
@@ -43,9 +42,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .where(getFilterExpression(command)) // 내가 업로드한 게시글
                 .where(post.user.id.notIn(
                         JPAExpressions
-                                .select(ignoredUsers.ignoredUser.id)
+                                .select(ignoredUsers.ignoredUsersRelation.ignoredUser.id)
                                 .from(ignoredUsers)
-                                .where(ignoredUsers.ignoredUser.id.eq(command.getUserId()))
+                                .where(ignoredUsers.ignoredUsersRelation.user.id.eq(command.getUserId()))
                 )) //본인이 ignore한 게시글 제거
                 .where(post.id.notIn(
                         JPAExpressions

--- a/src/test/java/com/nexters/phochak/repository/IgnoredUserRepositoryTest.java
+++ b/src/test/java/com/nexters/phochak/repository/IgnoredUserRepositoryTest.java
@@ -7,19 +7,21 @@ import com.nexters.phochak.specification.OAuthProviderEnum;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Transactional
+@ActiveProfiles("test")
 @SpringBootTest
 class IgnoredUserRepositoryTest {
 
     @Autowired IgnoredUserRepository ignoredUserRepository;
     @Autowired UserRepository userRepository;
 
+    @Transactional
     @Test
     public void save() {
         // given
@@ -49,6 +51,7 @@ class IgnoredUserRepositoryTest {
         assertTrue(ignoredUserRepository.existsByIgnoredUsersRelation(ignoredUsersRelation));
     }
 
+    @Transactional
     @Test
     public void getIgnoreUserListByUserId() {
         // given
@@ -87,6 +90,9 @@ class IgnoredUserRepositoryTest {
 
         // then
         List<IgnoredUsers> list = ignoredUserRepository.getIgnoreUserListByUserId(me.getId());
+        for (IgnoredUsers users : list) {
+            System.out.println(users.getIgnoredUsersRelation().getIgnoredUser().getId());
+        }
         assertEquals(2, list.size());
         assertEquals(2L, list.get(0).getIgnoredUsersRelation().getIgnoredUser().getId());
         assertEquals(3L, list.get(1).getIgnoredUsersRelation().getIgnoredUser().getId());

--- a/src/test/java/com/nexters/phochak/repository/IgnoredUserRepositoryTest.java
+++ b/src/test/java/com/nexters/phochak/repository/IgnoredUserRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.nexters.phochak.repository;
+
+import com.nexters.phochak.domain.IgnoredUsers;
+import com.nexters.phochak.domain.IgnoredUsersRelation;
+import com.nexters.phochak.domain.User;
+import com.nexters.phochak.specification.OAuthProviderEnum;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+class IgnoredUserRepositoryTest {
+
+    @Autowired IgnoredUserRepository ignoredUserRepository;
+    @Autowired UserRepository userRepository;
+
+    @Test
+    public void save() {
+        // given
+        User me = User.builder()
+                .id(1L)
+                .nickname("me")
+                .provider(OAuthProviderEnum.KAKAO)
+                .providerId("000")
+                .profileImgUrl("some_url0")
+                .build();
+        userRepository.save(me);
+        User user1 = User.builder()
+                .id(2L)
+                .nickname("user1")
+                .provider(OAuthProviderEnum.KAKAO)
+                .providerId("111")
+                .profileImgUrl("some_url1")
+                .build();
+        userRepository.save(user1);
+
+        // when
+        IgnoredUsersRelation ignoredUsersRelation = new IgnoredUsersRelation(me, user1);
+        IgnoredUsers ignoredUsers = new IgnoredUsers(ignoredUsersRelation);
+        ignoredUserRepository.save(ignoredUsers);
+
+        // then
+        assertTrue(ignoredUserRepository.existsByIgnoredUsersRelation(ignoredUsersRelation));
+    }
+
+    @Test
+    public void getIgnoreUserListByUserId() {
+        // given
+        User me = User.builder()
+                .id(1L)
+                .nickname("me")
+                .provider(OAuthProviderEnum.KAKAO)
+                .providerId("1")
+                .profileImgUrl("some_url1")
+                .build();
+        userRepository.save(me);
+        User user2 = User.builder()
+                .id(2L)
+                .nickname("user2")
+                .provider(OAuthProviderEnum.KAKAO)
+                .providerId("2")
+                .profileImgUrl("some_url2")
+                .build();
+        userRepository.save(user2);
+        User user3 = User.builder()
+                .id(3L)
+                .nickname("user3")
+                .provider(OAuthProviderEnum.KAKAO)
+                .providerId("3")
+                .profileImgUrl("some_url3")
+                .build();
+        userRepository.save(user3);
+
+        // when
+        IgnoredUsersRelation ignoredUsersRelation = new IgnoredUsersRelation(me, user2);
+        IgnoredUsers ignoredUsers = new IgnoredUsers(ignoredUsersRelation);
+        ignoredUserRepository.save(ignoredUsers);
+        IgnoredUsersRelation ignoredUsersRelation2 = new IgnoredUsersRelation(me, user3);
+        IgnoredUsers ignoredUsers2 = new IgnoredUsers(ignoredUsersRelation2);
+        ignoredUserRepository.save(ignoredUsers2);
+
+        // then
+        List<IgnoredUsers> list = ignoredUserRepository.getIgnoreUserListByUserId(me.getId());
+        assertEquals(2, list.size());
+        assertEquals(2L, list.get(0).getIgnoredUsersRelation().getIgnoredUser().getId());
+        assertEquals(3L, list.get(1).getIgnoredUsersRelation().getIgnoredUser().getId());
+    }
+
+}


### PR DESCRIPTION
❗️ 이슈 번호
close #169 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

버그 핫픽스!

기존 엔티티 복합키 적용을 운영 DB에 호다닥 처리했었는데,
Spring Data JPA 타입 이슈로 예상치 못한 작동을 하더군요.

복합키로 연관관계까지 설정하는 방식과, EmbeddedId로 새롭게 정의한 타입을 통해 Spring Data JPA 를 사용하는 방법도 공부했네요.


🙇🏻‍♂️ 리뷰어에게 부탁합니다!
(리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)



💡 참고 자료
(없다면 지워도 됩니다!)
