### PR TITLE
chore: [RE] 운영 서버의 CD가 release 브랜치를 가리키도록 변경

### DIFF
--- a/.github/workflows/actions-merge.yml
+++ b/.github/workflows/actions-merge.yml
@@ -2,7 +2,7 @@ name: CI/CD-workflow
 
 on:
   push:
-    branches: ["develop"]
+    branches: ["release"]
 
 jobs:
   build:


### PR DESCRIPTION
❗️ 이슈 번호
close #175

Merge 실수로 다시 올립니다.

📝 구현 내용

- 이제 운영 서버 CD가 release 브랜치로 향하도록 변경합니다.
- 추가 기능 개발이나 리팩토링 시에 git-flow를 준수합니다.
