### PR TITLE
refactor: 해시태그 feaeture 리팩토링

### DIFF
--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagCustomRepositoryImpl.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagCustomRepositoryImpl.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 import java.util.List;
 import java.util.Map;
 
-import static com.nexters.phochak.post.adapter.out.persistence.QHashtag.hashtag;
+import static com.nexters.phochak.post.adapter.out.persistence.QHashtagEntity.hashtagEntity;
 import static com.nexters.phochak.post.adapter.out.persistence.QPostEntity.postEntity;
 import static com.nexters.phochak.post.adapter.out.persistence.QReportPost.reportPost;
 import static com.nexters.phochak.user.adapter.out.persistence.QIgnoredUserEntity.ignoredUserEntity;
@@ -29,10 +29,10 @@ public class HashtagCustomRepositoryImpl implements HashtagCustomRepository {
 
     @Override
     public Map<Long, HashtagFetchDto> findHashTagsOfPost(List<Long> postIds) {
-        return queryFactory.from(hashtag)
-                .where(hashtag.post.id.in(postIds))
-                .transform(groupBy(hashtag.post.id)
-                        .as(new QHashtagFetchDto(list(hashtag.tag))));
+        return queryFactory.from(hashtagEntity)
+                .where(hashtagEntity.post.id.in(postIds))
+                .transform(groupBy(hashtagEntity.post.id)
+                        .as(new QHashtagFetchDto(list(hashtagEntity.tag))));
     }
 
     @Override

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
@@ -21,7 +21,7 @@ import lombok.Getter;
 @Table(indexes =
         {@Index(name = "idx01_hashtag", columnList = "TAG"),
         @Index(name = "idx02_hashtag", columnList = "POST_ID")})
-public class Hashtag {
+public class HashtagEntity {
     public static final int HASHTAG_MAX_SIZE = 20;
 
     @Id
@@ -37,11 +37,11 @@ public class Hashtag {
     @Size(min = 1, max = HASHTAG_MAX_SIZE)
     private String tag;
 
-    public Hashtag() {
+    public HashtagEntity() {
     }
 
     @Builder
-    public Hashtag(PostEntity post, String tag) {
+    public HashtagEntity(PostEntity post, String tag) {
         this.post = post;
         this.tag = tag;
     }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagFetchDto.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagFetchDto.java
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 public class HashtagFetchDto {
     List<String> hashtags;
 
-    public static HashtagFetchDto from(List<Hashtag> hashtag) {
-        List<String> hashtags = hashtag.stream()
-                .map(Hashtag::getTag)
+    public static HashtagFetchDto from(List<HashtagEntity> hashtagEntity) {
+        List<String> hashtags = hashtagEntity.stream()
+                .map(HashtagEntity::getTag)
                 .collect(Collectors.toList());
 
         return HashtagFetchDto.builder()

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
@@ -1,0 +1,24 @@
+package com.nexters.phochak.post.adapter.out.persistence;
+
+import com.nexters.phochak.post.domain.Hashtag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class HashtagMapper {
+
+    private final PostMapper postMapper;
+
+    public HashtagEntity toEntity(final Hashtag hashtag) {
+        return new HashtagEntity(
+                postMapper.toEntity(hashtag.getPost()),
+                hashtag.getTag());
+    }
+
+    public Hashtag toDomain(final HashtagEntity hashtagEntity) {
+        return new Hashtag(
+                postMapper.toDomain(hashtagEntity.getPost()),
+                hashtagEntity.getTag());
+    }
+}

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagRepository.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagRepository.java
@@ -8,17 +8,17 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface HashtagRepository extends JpaRepository<Hashtag, Long>, HashtagCustomRepository {
+public interface HashtagRepository extends JpaRepository<HashtagEntity, Long>, HashtagCustomRepository {
 
-    @Query("delete from Hashtag h where h.post.id = :postId")
+    @Query("delete from HashtagEntity h where h.post.id = :postId")
     @Modifying
     void deleteAllByPostId(@Param("postId") Long postId);
 
-    @Query("delete from Hashtag h where h.post.id IN (:postIdList)")
+    @Query("delete from HashtagEntity h where h.post.id IN (:postIdList)")
     @Modifying
     void deleteAllByPostIdIn(@Param("postIdList") List<Long> postIdList);
 
-    @Query("select distinct h.tag from Hashtag h where h.tag like :hashtag% order by length(h.tag)")
+    @Query("select distinct h.tag from HashtagEntity h where h.tag like :hashtag% order by length(h.tag)")
     List<String> findByHashtagStartsWith(@Param("hashtag") String hashtag, Pageable pageable);
 
     boolean existsByTag(String tag);

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
@@ -8,19 +8,22 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class LikesMapper {
-
-    private final UserMapper userMapper;
     private final PostMapper postMapper;
+    private final UserMapper userMapper;
 
-    public LikesEntity toEntity(final Likes likes) {
+    public LikesEntity toEntity(Likes like) {
         return new LikesEntity(
-                userMapper.toEntity(likes.getUser()),
-                postMapper.toEntity(likes.getPost()));
+                userMapper.toEntity(like.getUser()),
+                postMapper.toEntity(like.getPost())
+        );
     }
 
-    public Likes toDomain(final LikesEntity likesEntity) {
+    public Likes toDomain(LikesEntity likeEntity) {
         return new Likes(
-                userMapper.toDomain(likesEntity.getUser()),
-                postMapper.toDomain(likesEntity.getPost()));
+                likeEntity.getId(),
+                postMapper.toDomain(likeEntity.getPost()),
+                userMapper.toDomain(likeEntity.getUser())
+        );
     }
+
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
@@ -68,7 +68,7 @@ public class PostEntity extends BaseTime {
     private List<LikesEntity> likes;
 
     @OneToMany(mappedBy = "post")
-    private List<Hashtag> hashtags;
+    private List<HashtagEntity> hashtagEntities;
 
     public PostEntity() {
     }
@@ -83,7 +83,7 @@ public class PostEntity extends BaseTime {
     }
 
 
-    public PostEntity(final Long id, final UserEntity user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<Hashtag> hashtags) {
+    public PostEntity(final Long id, final UserEntity user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<HashtagEntity> hashtagEntities) {
         this.id = id;
         this.user = user;
         this.shorts = shorts;
@@ -92,7 +92,7 @@ public class PostEntity extends BaseTime {
         this.postCategory = postCategory;
         this.isBlind = isBlind;
         this.likes = likes;
-        this.hashtags = hashtags;
+        this.hashtagEntities = hashtagEntities;
     }
 
     public void setShorts(Shorts shorts) {

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
@@ -83,7 +83,7 @@ public class PostEntity extends BaseTime {
     }
 
 
-    public PostEntity(final Long id, final UserEntity user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<HashtagEntity> hashtags) {
+    public PostEntity(final Long id, final UserEntity user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind) {
         this.id = id;
         this.user = user;
         this.shorts = shorts;
@@ -91,8 +91,6 @@ public class PostEntity extends BaseTime {
         this.view = view;
         this.postCategory = postCategory;
         this.isBlind = isBlind;
-        this.likes = likes;
-        this.hashtags = hashtags;
     }
 
     public void setShorts(Shorts shorts) {

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
@@ -68,7 +68,7 @@ public class PostEntity extends BaseTime {
     private List<LikesEntity> likes;
 
     @OneToMany(mappedBy = "post")
-    private List<HashtagEntity> hashtagEntities;
+    private List<HashtagEntity> hashtags;
 
     public PostEntity() {
     }
@@ -83,7 +83,7 @@ public class PostEntity extends BaseTime {
     }
 
 
-    public PostEntity(final Long id, final UserEntity user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<HashtagEntity> hashtagEntities) {
+    public PostEntity(final Long id, final UserEntity user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<HashtagEntity> hashtags) {
         this.id = id;
         this.user = user;
         this.shorts = shorts;
@@ -92,7 +92,7 @@ public class PostEntity extends BaseTime {
         this.postCategory = postCategory;
         this.isBlind = isBlind;
         this.likes = likes;
-        this.hashtagEntities = hashtagEntities;
+        this.hashtags = hashtags;
     }
 
     public void setShorts(Shorts shorts) {

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostMapper {
     private final UserMapper userMapper;
+
     public PostEntity toEntity(Post post) {
         return new PostEntity(
                 post.getId(),
@@ -17,10 +18,7 @@ public class PostMapper {
                 post.getReportPost(),
                 post.getView(),
                 post.getPostCategory(),
-                post.isBlind(),
-                post.getLikes(),
-                post.getHashtagEntities()
-        );
+                post.isBlind());
     }
 
     public Post toDomain(PostEntity postEntity) {
@@ -31,9 +29,6 @@ public class PostMapper {
                 postEntity.getReportPost(),
                 postEntity.getView(),
                 postEntity.getPostCategory(),
-                postEntity.isBlind(),
-                postEntity.getLikes(),
-                postEntity
-                        .getHashtags());
+                postEntity.isBlind());
     }
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
@@ -33,6 +33,7 @@ public class PostMapper {
                 postEntity.getPostCategory(),
                 postEntity.isBlind(),
                 postEntity.getLikes(),
-                postEntity.getHashtagEntities());
+                postEntity
+                        .getHashtags());
     }
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
@@ -19,7 +19,7 @@ public class PostMapper {
                 post.getPostCategory(),
                 post.isBlind(),
                 post.getLikes(),
-                post.getHashtags()
+                post.getHashtagEntities()
         );
     }
 
@@ -33,6 +33,6 @@ public class PostMapper {
                 postEntity.getPostCategory(),
                 postEntity.isBlind(),
                 postEntity.getLikes(),
-                postEntity.getHashtags());
+                postEntity.getHashtagEntities());
     }
 }

--- a/src/main/java/com/nexters/phochak/post/application/HashtagService.java
+++ b/src/main/java/com/nexters/phochak/post/application/HashtagService.java
@@ -2,7 +2,7 @@ package com.nexters.phochak.post.application;
 
 import com.nexters.phochak.common.exception.PhochakException;
 import com.nexters.phochak.common.exception.ResCode;
-import com.nexters.phochak.post.adapter.out.persistence.Hashtag;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
 import com.nexters.phochak.post.adapter.out.persistence.HashtagFetchDto;
 import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
 import com.nexters.phochak.post.adapter.out.persistence.PostMapper;
@@ -24,18 +24,18 @@ public class HashtagService implements HashtagUseCase {
     private final PostMapper postMapper;
 
     @Override
-    public List<Hashtag> saveHashtags(Post post, List<String> stringHashtagList) {
+    public List<HashtagEntity> saveHashtags(Post post, List<String> stringHashtagList) {
         if (stringHashtagList.isEmpty()) {
             return Collections.emptyList();
         }
         validateHashtag(stringHashtagList);
-        List<Hashtag> hashtagList = stringHashtagList.stream().map(stringHashtag ->
-                Hashtag.builder()
+        List<HashtagEntity> hashtagEntityList = stringHashtagList.stream().map(stringHashtag ->
+                HashtagEntity.builder()
                         .post(postMapper.toEntity(post))
                         .tag(stringHashtag)
                         .build()
         ).toList();
-        return hashtagRepository.saveAll(hashtagList);
+        return hashtagRepository.saveAll(hashtagEntityList);
     }
 
     @Override

--- a/src/main/java/com/nexters/phochak/post/application/port/in/CustomCursorDto.java
+++ b/src/main/java/com/nexters/phochak/post/application/port/in/CustomCursorDto.java
@@ -26,7 +26,7 @@ public class CustomCursorDto {
     private String hashtag;
 
     @Builder
-    public CustomCursorDto(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter, Long targetUserId, PostCategoryEnum category) {
+    public CustomCursorDto(Long lastId, Integer pageSize, PostSortOption sortOption, Integer sortValue, PostFilter filter, Long targetUserId, PostCategoryEnum category, String hashtag) {
         this.lastId = lastId;
         this.pageSize = Objects.isNull(pageSize) ? DEFAULT_PAGE_SIZE : pageSize;
         this.sortOption = Objects.isNull(sortOption) ? PostSortOption.LATEST : sortOption;
@@ -34,6 +34,7 @@ public class CustomCursorDto {
         this.filter = Objects.isNull(filter) ? PostFilter.NONE : filter;
         this.targetUserId = targetUserId;
         this.category = category;
+        this.hashtag = hashtag;
 
         // 첫 요청 시 lastId, sortValue는 null로, sortOption만 받음
         if (Objects.isNull(lastId) && Objects.isNull(this.sortValue)) {

--- a/src/main/java/com/nexters/phochak/post/application/port/in/HashtagUseCase.java
+++ b/src/main/java/com/nexters/phochak/post/application/port/in/HashtagUseCase.java
@@ -1,6 +1,5 @@
 package com.nexters.phochak.post.application.port.in;
 
-import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
 import com.nexters.phochak.post.adapter.out.persistence.HashtagFetchDto;
 import com.nexters.phochak.post.domain.Post;
 
@@ -8,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface HashtagUseCase {
-    List<HashtagEntity> saveHashtags(Post post, List<String> stringHashtagList);
+    void saveHashtags(Post post, List<String> stringHashtagList);
 
     Map<Long, HashtagFetchDto> findHashtagsOfPosts(List<Long> postIds);
 

--- a/src/main/java/com/nexters/phochak/post/application/port/in/HashtagUseCase.java
+++ b/src/main/java/com/nexters/phochak/post/application/port/in/HashtagUseCase.java
@@ -1,6 +1,6 @@
 package com.nexters.phochak.post.application.port.in;
 
-import com.nexters.phochak.post.adapter.out.persistence.Hashtag;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
 import com.nexters.phochak.post.adapter.out.persistence.HashtagFetchDto;
 import com.nexters.phochak.post.domain.Post;
 
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 public interface HashtagUseCase {
-    List<Hashtag> saveHashtags(Post post, List<String> stringHashtagList);
+    List<HashtagEntity> saveHashtags(Post post, List<String> stringHashtagList);
 
     Map<Long, HashtagFetchDto> findHashtagsOfPosts(List<Long> postIds);
 

--- a/src/main/java/com/nexters/phochak/post/application/port/out/SaveHashtagAdapter.java
+++ b/src/main/java/com/nexters/phochak/post/application/port/out/SaveHashtagAdapter.java
@@ -1,0 +1,24 @@
+package com.nexters.phochak.post.application.port.out;
+
+import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagMapper;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
+import com.nexters.phochak.post.domain.Hashtag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SaveHashtagAdapter implements SaveHashtagPort {
+
+    private final HashtagRepository hashtagRepository;
+    private final HashtagMapper hashtagMapper;
+
+    @Override
+    public void saveAll(final List<Hashtag> hashtagList) {
+        final List<HashtagEntity> hashtagEntityList = hashtagList.stream().map(hashtagMapper::toEntity).toList();
+        hashtagRepository.saveAll(hashtagEntityList);
+    }
+}

--- a/src/main/java/com/nexters/phochak/post/application/port/out/SaveHashtagPort.java
+++ b/src/main/java/com/nexters/phochak/post/application/port/out/SaveHashtagPort.java
@@ -1,0 +1,9 @@
+package com.nexters.phochak.post.application.port.out;
+
+import com.nexters.phochak.post.domain.Hashtag;
+
+import java.util.List;
+
+public interface SaveHashtagPort {
+    void saveAll(List<Hashtag> hashtagList);
+}

--- a/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
@@ -1,25 +1,38 @@
 package com.nexters.phochak.post.domain;
 
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+import com.nexters.phochak.common.exception.PhochakException;
+import com.nexters.phochak.common.exception.ResCode;
+import lombok.Getter;
 import org.springframework.util.Assert;
 
+import java.util.regex.Pattern;
+
+@Getter
 public class Hashtag {
     public static final int HASHTAG_MAX_SIZE = 20;
     private Long id;
-    private PostEntity post;
+    private Post post;
     private String tag;
 
-    public Hashtag(PostEntity post, String tag) {
+    public Hashtag(Post post, String tag) {
         validateConstructor(post, tag);
         this.post = post;
         this.tag = tag;
     }
 
-    private static void validateConstructor(final PostEntity post, final String tag) {
+    private static void validateConstructor(final Post post, final String tag) {
         Assert.notNull(post, "post must not be null");
         Assert.notNull(tag, "tag must not be null");
         if (tag.length() > HASHTAG_MAX_SIZE) {
             throw new IllegalArgumentException("tag must not be longer than " + HASHTAG_MAX_SIZE);
+        }
+        validateHashtagString(tag);
+    }
+
+    private static void validateHashtagString(final String tag) {
+        final Pattern pattern = Pattern.compile("[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣_]{1,20}$");
+        if (!pattern.matcher(tag).matches()) {
+            throw new PhochakException(ResCode.INVALID_INPUT, "해시태그 형식이 올바르지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
@@ -1,0 +1,25 @@
+package com.nexters.phochak.post.domain;
+
+import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+import org.springframework.util.Assert;
+
+public class Hashtag {
+    public static final int HASHTAG_MAX_SIZE = 20;
+    private Long id;
+    private PostEntity post;
+    private String tag;
+
+    public Hashtag(PostEntity post, String tag) {
+        validateConstructor(post, tag);
+        this.post = post;
+        this.tag = tag;
+    }
+
+    private static void validateConstructor(final PostEntity post, final String tag) {
+        Assert.notNull(post, "post must not be null");
+        Assert.notNull(tag, "tag must not be null");
+        if (tag.length() > HASHTAG_MAX_SIZE) {
+            throw new IllegalArgumentException("tag must not be longer than " + HASHTAG_MAX_SIZE);
+        }
+    }
+}

--- a/src/main/java/com/nexters/phochak/post/domain/Likes.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Likes.java
@@ -5,12 +5,23 @@ import lombok.Getter;
 
 @Getter
 public class Likes {
+    private Long id;
     private final User user;
     private final Post post;
 
     public Likes(final User user, final Post post) {
-
+        this.id = null;
         this.user = user;
         this.post = post;
+    }
+
+    public Likes(final Long id, final Post post, final User user) {
+        this.id = id;
+        this.user = user;
+        this.post = post;
+    }
+
+    public void assignId(Long id) {
+        this.id = id;
     }
 }

--- a/src/main/java/com/nexters/phochak/post/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Post.java
@@ -1,7 +1,5 @@
 package com.nexters.phochak.post.domain;
 
-import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
-import com.nexters.phochak.post.adapter.out.persistence.LikesEntity;
 import com.nexters.phochak.post.adapter.out.persistence.ReportPost;
 import com.nexters.phochak.shorts.domain.Shorts;
 import com.nexters.phochak.user.domain.User;
@@ -20,10 +18,10 @@ public class Post {
     private User user;
     private Shorts shorts;
     private List<ReportPost> reportPost = new ArrayList<>();
-    private List<LikesEntity> likes = new ArrayList<>();
-    private List<HashtagEntity> hashtagEntities = new ArrayList<>();
+    private List<Likes> likes = new ArrayList<>();
+    private List<Hashtag> hashtagList = new ArrayList<>();
 
-    public Post(final Long id, final User user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<HashtagEntity> hashtagEntities) {
+    public Post(final Long id, final User user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind) {
         this.id = id;
         this.user = user;
         this.shorts = shorts;
@@ -31,8 +29,6 @@ public class Post {
         this.view = view;
         this.postCategory = postCategory;
         this.isBlind = isBlind;
-        this.likes = likes;
-        this.hashtagEntities = hashtagEntities;
     }
 
     public Post(final User user, final PostCategoryEnum postCategory) {
@@ -52,5 +48,9 @@ public class Post {
 
     public void updateContent(final PostCategoryEnum postCategoryEnum) {
         this.postCategory = postCategoryEnum;
+    }
+
+    public void setHashtagList(final List<Hashtag> hashtagList) {
+        this.hashtagList = hashtagList;
     }
 }

--- a/src/main/java/com/nexters/phochak/post/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Post.java
@@ -1,6 +1,6 @@
 package com.nexters.phochak.post.domain;
 
-import com.nexters.phochak.post.adapter.out.persistence.Hashtag;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
 import com.nexters.phochak.post.adapter.out.persistence.LikesEntity;
 import com.nexters.phochak.post.adapter.out.persistence.ReportPost;
 import com.nexters.phochak.shorts.domain.Shorts;
@@ -21,9 +21,9 @@ public class Post {
     private Shorts shorts;
     private List<ReportPost> reportPost = new ArrayList<>();
     private List<LikesEntity> likes = new ArrayList<>();
-    private List<Hashtag> hashtags = new ArrayList<>();
+    private List<HashtagEntity> hashtagEntities = new ArrayList<>();
 
-    public Post(final Long id, final User user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<Hashtag> hashtags) {
+    public Post(final Long id, final User user, final Shorts shorts, final List<ReportPost> reportPost, final Long view, final PostCategoryEnum postCategory, final boolean isBlind, final List<LikesEntity> likes, final List<HashtagEntity> hashtagEntities) {
         this.id = id;
         this.user = user;
         this.shorts = shorts;
@@ -32,7 +32,7 @@ public class Post {
         this.postCategory = postCategory;
         this.isBlind = isBlind;
         this.likes = likes;
-        this.hashtags = hashtags;
+        this.hashtagEntities = hashtagEntities;
     }
 
     public Post(final User user, final PostCategoryEnum postCategory) {

--- a/src/test/java/com/nexters/phochak/common/DocumentGenerator.java
+++ b/src/test/java/com/nexters/phochak/common/DocumentGenerator.java
@@ -241,7 +241,8 @@ public class DocumentGenerator {
                         parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
                         parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
                         parameterWithName("lastId").description("(선택) 초기 요청에서는 필요하지 않음").optional(),
-                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                        parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional()
                 ),
                 requestHeaders(
                         headerWithName(AUTHORIZATION_HEADER)
@@ -277,7 +278,8 @@ public class DocumentGenerator {
                         parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
                         parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
                         parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                        parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional()
                 ),
                 requestHeaders(
                         headerWithName(AUTHORIZATION_HEADER)
@@ -313,7 +315,8 @@ public class DocumentGenerator {
                         parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
                         parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
                         parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
-                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                        parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional()
                 ),
                 requestHeaders(
                         headerWithName(AUTHORIZATION_HEADER)
@@ -427,7 +430,8 @@ public class DocumentGenerator {
                         parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)").optional(),
                         parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
                         parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)")
+                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                        parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional()
                 ),
                 requestHeaders(
                         headerWithName(AUTHORIZATION_HEADER)

--- a/src/test/java/com/nexters/phochak/common/DocumentGenerator.java
+++ b/src/test/java/com/nexters/phochak/common/DocumentGenerator.java
@@ -454,4 +454,43 @@ public class DocumentGenerator {
                 )
         ));
     }
+
+    public static void getPostList_searched(final ResultActions response) throws Exception {
+        response.andDo(document("post/list/liked",
+                preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                queryParameters(
+                        parameterWithName("sortOption").description("(필수) 게시글 정렬 기준 (LIKE/LATEST/VIEW)"),
+                        parameterWithName("sortValue").description("(sortOption이 LATEST인 경우를 제외하고 필수) 마지막으로 받은 페이지의 마지막 게시글의 정렬 기준 값(LIKE면 좋아요 수, VIEW면 조회수)").optional(),
+                        parameterWithName("lastId").description("(필수) 마지막으로 받은 게시글 id"),
+                        parameterWithName("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
+                        parameterWithName("filter").description("(선택) 마이페이지 필터 조건 (UPLOADED: 내가 업로드한 동영상/LIKED: 내가 좋아요한 동영상)"),
+                        parameterWithName("category").description("(선택) 게시글 카테고리 ex) CAFE").optional(),
+                        parameterWithName("hashtag").description("(선택) 검색할 해시태그").optional()
+                ),
+                requestHeaders(
+                        headerWithName(AUTHORIZATION_HEADER)
+                                .description("(필수) JWT Access Token")
+                ),
+                responseFields(
+                        fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+                        fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+                        fieldWithPath("isLastPage").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
+                        fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("게시글 id"),
+                        fieldWithPath("data[].user.id").type(JsonFieldType.NUMBER).description("유저 id"),
+                        fieldWithPath("data[].user.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
+                        fieldWithPath("data[].user.profileImgUrl").type(JsonFieldType.STRING).description("유저 프로필 이미지 링크"),
+                        fieldWithPath("data[].shorts.id").type(JsonFieldType.NUMBER).description("영상 id"),
+                        fieldWithPath("data[].shorts.state").type(JsonFieldType.STRING).description("현재 shorts 인코딩 상태(OK, FAIL, IN_PROGRESS)"),
+                        fieldWithPath("data[].shorts.thumbnailUrl").type(JsonFieldType.STRING).description("영상 썸네일 이미지 링크"),
+                        fieldWithPath("data[].shorts.shortsUrl").type(JsonFieldType.STRING).description("영상 링크"),
+                        fieldWithPath("data[].hashtags").type(JsonFieldType.ARRAY).description("해시태그 목록"),
+                        fieldWithPath("data[].view").type(JsonFieldType.NUMBER).description("조회수"),
+                        fieldWithPath("data[].category").type(JsonFieldType.STRING).description("게시글 카테고리"),
+                        fieldWithPath("data[].like").type(JsonFieldType.NUMBER).description("좋아요 수"),
+                        fieldWithPath("data[].isLiked").type(JsonFieldType.BOOLEAN).description("조회한 유저의 좋아요 여부"),
+                        fieldWithPath("data[].isBlind").type(JsonFieldType.BOOLEAN).description("해당 게시글의 신고 누적 여부")
+                )
+        ));
+    }
 }

--- a/src/test/java/com/nexters/phochak/deprecated/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/AuthIntegrationTest.java
@@ -3,7 +3,7 @@ package com.nexters.phochak.deprecated.integration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nexters.phochak.common.docs.RestDocs;
 import com.nexters.phochak.common.exception.CustomExceptionHandler;
-import com.nexters.phochak.post.adapter.out.persistence.Hashtag;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
 import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
 import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
 import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
@@ -253,8 +253,8 @@ public class AuthIntegrationTest extends RestDocs {
                     .build();
             postRepository.save(postEntity);
 
-            List<Hashtag> hashtags = List.of(new Hashtag(postEntity, "hashtag1"), new Hashtag(postEntity, "hashtag2"), new Hashtag(postEntity, "hashtag3"));
-            hashtagRepository.saveAll(hashtags);
+            List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
+            hashtagRepository.saveAll(hashtagEntities);
         }
 
         refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());

--- a/src/test/java/com/nexters/phochak/deprecated/integration/PostNcpIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/PostNcpIntegrationTest.java
@@ -5,7 +5,7 @@ import com.nexters.phochak.common.docs.RestDocs;
 import com.nexters.phochak.common.exception.CustomExceptionHandler;
 import com.nexters.phochak.post.adapter.in.web.PostController;
 import com.nexters.phochak.post.adapter.out.api.ReportNotificationFeignClient;
-import com.nexters.phochak.post.adapter.out.persistence.Hashtag;
+import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
 import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
 import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
 import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
@@ -192,8 +192,8 @@ class PostNcpIntegrationTest extends RestDocs {
         postRepository.save(postEntity);
         Long postId = postEntity.getId();
 
-        List<Hashtag> hashtags = List.of(new Hashtag(postEntity, "hashtag1"), new Hashtag(postEntity, "hashtag2"), new Hashtag(postEntity, "hashtag3"));
-        hashtagRepository.saveAll(hashtags);
+        List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
+        hashtagRepository.saveAll(hashtagEntities);
 
         em.flush();
         em.clear();
@@ -252,8 +252,8 @@ class PostNcpIntegrationTest extends RestDocs {
         postRepository.save(postEntity);
         Long postId = postEntity.getId();
 
-        List<Hashtag> hashtags = List.of(new Hashtag(postEntity, "hashtag1"), new Hashtag(postEntity, "hashtag2"), new Hashtag(postEntity, "hashtag3"));
-        hashtagRepository.saveAll(hashtags);
+        List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
+        hashtagRepository.saveAll(hashtagEntities);
 
         em.flush();
         em.clear();

--- a/src/test/java/com/nexters/phochak/post/PostControllerPagingTest.java
+++ b/src/test/java/com/nexters/phochak/post/PostControllerPagingTest.java
@@ -20,6 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import java.util.List;
+
 class PostControllerPagingTest extends RestDocsApiTest {
     @Autowired
     PostController postController;
@@ -220,84 +222,29 @@ class PostControllerPagingTest extends RestDocsApiTest {
         DocumentGenerator.getPostList_liked(response);
     }
 
-    //
-//    @Test
-//    @DisplayName("포스트 목록 조회 API - 해시태그 검색")
-//    void getPostList_searched() throws Exception {
-//        CustomCursorDto customCursorDto = CustomCursorDto.builder()
-//                .pageSize(3)
-//                .lastId(20L)
-//                .category(PostCategoryEnum.CAFE)
-//                .build();
-//
-//        List<String> hashtags = List.of("해시태그1", "해시태그2");
-//
-//        PostFetchDto.PostUserInformation newUser = PostFetchDto.PostUserInformation.builder()
-//                .id(4L)
-//                .nickname("newUser")
-//                .profileImgUrl("profileImage")
-//                .build();
-//
-//        PostPageResponseDto post3 = PostPageResponseDto.builder()
-//                .id(20L)
-//                .user(newUser)
-//                .shorts(shorts)
-//                .view(1000)
-//                .category(PostCategoryEnum.CAFE)
-//                .like(120)
-//                .isLiked(Boolean.TRUE)
-//                .hashtags(hashtags)
-//                .isBlind(Boolean.FALSE)
-//                .build();
-//
-//        List<PostPageResponseDto> result = List.of(post3, post1);
-//
-//
-//        when(postUseCase.getNextCursorPage(any(), anyString())).thenReturn(result);
-//
-//        mockMvc.perform(
-//                        RestDocumentationRequestBuilders
-//                                .get("/v1/post/list/search")
-//                                .param("lastId", String.valueOf(customCursorDto.getLastId()))
-//                                .param("pageSize", String.valueOf(customCursorDto.getPageSize()))
-//                                .param("hashtag", String.valueOf(hashtags.get(1)))
-//                                .param("category", String.valueOf(customCursorDto.getCategory()))
-//                                .header(AUTHORIZATION_HEADER, "access token")
-//                )
-//                .andExpect(status().isOk())
-//                .andDo(document("post/list/search",
-//                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
-//                        preprocessResponse(prettyPrint()),
-//                        requestFields(
-//                                fieldWithPath("lastId").description("(선택) 마지막으로 받은 게시글 id"),
-//                                fieldWithPath("pageSize").description("(선택) 페이지 크기(default: 5)").optional(),
-//                                fieldWithPath("hashtag").description("(선택) 검색할 해시태그").optional(),
-//                                fieldWithPath("category").description("(선택) 게시글 카테고리 ex) CAFE").optional()
-//                        ),
-//                        requestHeaders(
-//                                headerWithName(AUTHORIZATION_HEADER)
-//                                        .description("(필수) JWT Access Token")
-//                        ),
-//                        responseFields(
-//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-//                                fieldWithPath("isLastPage").type(JsonFieldType.BOOLEAN).description("마지막 페이지 여부"),
-//                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER).description("게시글 id"),
-//                                fieldWithPath("data[].user.id").type(JsonFieldType.NUMBER).description("유저 id"),
-//                                fieldWithPath("data[].user.nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
-//                                fieldWithPath("data[].user.profileImgUrl").type(JsonFieldType.STRING).description("유저 프로필 이미지 링크"),
-//                                fieldWithPath("data[].shorts.id").type(JsonFieldType.NUMBER).description("영상 id"),
-//                                fieldWithPath("data[].shorts.state").type(JsonFieldType.STRING).description("현재 shorts 인코딩 상태(OK, FAIL, IN_PROGRESS)"),
-//                                fieldWithPath("data[].shorts.thumbnailUrl").type(JsonFieldType.STRING).description("영상 썸네일 이미지 링크"),
-//                                fieldWithPath("data[].shorts.shortsUrl").type(JsonFieldType.STRING).description("영상 링크"),
-//                                fieldWithPath("data[].hashtags").type(JsonFieldType.ARRAY).description("해시태그 목록"),
-//                                fieldWithPath("data[].view").type(JsonFieldType.NUMBER).description("조회수"),
-//                                fieldWithPath("data[].category").type(JsonFieldType.STRING).description("게시글 카테고리"),
-//                                fieldWithPath("data[].like").type(JsonFieldType.NUMBER).description("좋아요 수"),
-//                                fieldWithPath("data[].isLiked").type(JsonFieldType.BOOLEAN).description("조회한 유저의 좋아요 여부"),
-//                                fieldWithPath("data[].isBlind").type(JsonFieldType.BOOLEAN).description("해당 게시글의 신고 누적 여부")
-//                        )
-//                ));
-//    }
+
+    @Test
+    @DisplayName("포스트 목록 조회 API - 해시태그 검색")
+    void getPostList_searched() throws Exception {
+
+        //given, when
+        final ResultActions response = Scenario.createPost().hashtagList(List.of("태그")).uploadKey("test1").request().advance()
+                .encodingCallback().status(EncodingStatusEnum.COMPLETE).filePathByUploadKey("test1").request().advance()
+                .createPost().hashtagList(List.of("태그")).uploadKey("test2").request().advance()
+                .encodingCallback().status(EncodingStatusEnum.COMPLETE).filePathByUploadKey("test2").request().advance()
+                .createPost().hashtagList(List.of("태그")).uploadKey("test3").request().advance()
+                .encodingCallback().status(EncodingStatusEnum.COMPLETE).filePathByUploadKey("test3").request().advance()
+                .createPost().uploadKey("test4").request().advance()
+                .encodingCallback().status(EncodingStatusEnum.COMPLETE).filePathByUploadKey("test4").request().advance()
+                .createPost().uploadKey("test5").request().advance()
+                .encodingCallback().status(EncodingStatusEnum.COMPLETE).filePathByUploadKey("test5").request().advance()
+                .getPostList().hashtag("태그").postFilter(PostFilter.SEARCH).pageSize(5).request().getResponse();
+
+        //then
+        response.andExpect(MockMvcResultMatchers.jsonPath("$.data.size()").value(3));
+
+        //docs
+        DocumentGenerator.getPostList_searched(response);
+    }
 
 }

--- a/src/test/java/com/nexters/phochak/post/api/GetPostApi.java
+++ b/src/test/java/com/nexters/phochak/post/api/GetPostApi.java
@@ -17,6 +17,7 @@ public class GetPostApi {
     private PostFilter postFilter = PostFilter.NONE;
     private int pageSize = 2;
     private Long lastId = null;
+    private String hashtag = null;
 
     public GetPostApi postSortOption(final PostSortOption postSortOption) {
         this.postSortOption = postSortOption;
@@ -38,12 +39,18 @@ public class GetPostApi {
         return this;
     }
 
+    public GetPostApi hashtag(final String hashtag) {
+        this.hashtag = hashtag;
+        return this;
+    }
+
     public Scenario.NextScenarioStep request() throws Exception {
         CustomCursorDto customCursorDto = CustomCursorDto.builder()
                 .sortOption(postSortOption)
                 .filter(postFilter)
                 .pageSize(pageSize)
                 .lastId(lastId)
+                .hashtag(hashtag)
                 .build();
 
         final ResultActions response = TestUtil.mockMvc.perform(
@@ -53,6 +60,7 @@ public class GetPostApi {
                                 .param("pageSize", String.valueOf(customCursorDto.getPageSize()))
                                 .param("lastId", String.valueOf(customCursorDto.getLastId()))
                                 .param("filter", customCursorDto.getFilter().name())
+                                .param("hashtag", customCursorDto.getHashtag())
                                 .header(AUTHORIZATION_HEADER, TestUtil.TestUser.accessToken))
                 .andExpect(status().isOk());
 


### PR DESCRIPTION
❗️ 이슈 번호
close #197 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)
- 도메인 객체와 엔티티를 분리
- 로직 port adapter 패턴으로 리팩토링
- mapper 클래스에서 양방향 객체에 대한 객체 삽입 제거
  - 그렇다면 load port에서 객체를 넣어주거나, mapper에서 다른 도메인 객체의 생성자를 호출해야 함.
  - DDD 에서 모든 객체는 완전한 것이 이상적이라고는 하지만, 1:N 조회로 성능 이슈가 생길 가능성이 크기 때문에 필요한 시점에 적용