### PR TITLE
refactor: 도메인 객체 및 엔티티 생성자 규칙 적용

### DIFF
--- a/src/main/java/com/nexters/phochak/notification/adapter/out/persistence/FcmDeviceTokenEntity.java
+++ b/src/main/java/com/nexters/phochak/notification/adapter/out/persistence/FcmDeviceTokenEntity.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -30,7 +29,6 @@ public class FcmDeviceTokenEntity extends BaseTime {
     @Column(nullable = false)
     private OperatingSystem operatingSystem;
 
-    @Builder
     public FcmDeviceTokenEntity(
             final Long id,
             final UserEntity user,
@@ -45,7 +43,4 @@ public class FcmDeviceTokenEntity extends BaseTime {
     public FcmDeviceTokenEntity() {
     }
 
-    public void updateDeviceToken(String token) {
-        this.token = token;
-    }
 }

--- a/src/main/java/com/nexters/phochak/notification/adapter/out/persistence/FcmDeviceTokenEntity.java
+++ b/src/main/java/com/nexters/phochak/notification/adapter/out/persistence/FcmDeviceTokenEntity.java
@@ -29,7 +29,7 @@ public class FcmDeviceTokenEntity extends BaseTime {
     @Column(nullable = false)
     private OperatingSystem operatingSystem;
 
-    public FcmDeviceTokenEntity(
+    FcmDeviceTokenEntity(
             final Long id,
             final UserEntity user,
             final String token,

--- a/src/main/java/com/nexters/phochak/notification/adapter/out/persistence/FcmDeviceTokenMapper.java
+++ b/src/main/java/com/nexters/phochak/notification/adapter/out/persistence/FcmDeviceTokenMapper.java
@@ -11,13 +11,11 @@ public class FcmDeviceTokenMapper {
     private final UserMapper userMapper;
 
     public FcmDeviceToken toDomain(FcmDeviceTokenEntity fcmDeviceTokenEntity) {
-        final FcmDeviceToken fcmDeviceToken = new FcmDeviceToken(
+        return FcmDeviceToken.forMapper(
+                fcmDeviceTokenEntity.getId(),
                 userMapper.toDomain(fcmDeviceTokenEntity.getUser()),
                 fcmDeviceTokenEntity.getToken(),
-                fcmDeviceTokenEntity.getOperatingSystem()
-        );
-        fcmDeviceToken.assignId(fcmDeviceTokenEntity.getId());
-        return fcmDeviceToken;
+                fcmDeviceTokenEntity.getOperatingSystem());
     }
 
     public FcmDeviceTokenEntity toEntity(FcmDeviceToken fcmDeviceToken) {
@@ -25,7 +23,6 @@ public class FcmDeviceTokenMapper {
                 fcmDeviceToken.getId(),
                 userMapper.toEntity(fcmDeviceToken.getUser()),
                 fcmDeviceToken.getToken(),
-                fcmDeviceToken.getOperatingSystem()
-        );
+                fcmDeviceToken.getOperatingSystem());
     }
 }

--- a/src/main/java/com/nexters/phochak/notification/domain/FcmDeviceToken.java
+++ b/src/main/java/com/nexters/phochak/notification/domain/FcmDeviceToken.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.notification.domain;
 
 import com.nexters.phochak.user.domain.User;
 import lombok.Getter;
+import org.springframework.util.Assert;
 
 @Getter
 public class FcmDeviceToken {
@@ -11,9 +12,16 @@ public class FcmDeviceToken {
     private final OperatingSystem operatingSystem;
 
     public FcmDeviceToken(final User user, final String token, final OperatingSystem operatingSystem) {
+        validateConstructor(user, token, operatingSystem);
         this.user = user;
         this.token = token;
         this.operatingSystem = operatingSystem;
+    }
+
+    private static void validateConstructor(final User user, final String token, final OperatingSystem operatingSystem) {
+        Assert.notNull(user, "user must not be null");
+        Assert.notNull(token, "token must not be null");
+        Assert.notNull(operatingSystem, "operatingSystem must not be null");
     }
 
     public void assignId(final Long id) {

--- a/src/main/java/com/nexters/phochak/notification/domain/FcmDeviceToken.java
+++ b/src/main/java/com/nexters/phochak/notification/domain/FcmDeviceToken.java
@@ -24,6 +24,17 @@ public class FcmDeviceToken {
         Assert.notNull(operatingSystem, "operatingSystem must not be null");
     }
 
+    private FcmDeviceToken(final Long id, final User user, final String token, final OperatingSystem operatingSystem) {
+        this.id = id;
+        this.user = user;
+        this.token = token;
+        this.operatingSystem = operatingSystem;
+    }
+
+    public static FcmDeviceToken forMapper(final Long id, final User user, final String token, final OperatingSystem operatingSystem) {
+        return new FcmDeviceToken(id, user, token, operatingSystem);
+    }
+
     public void assignId(final Long id) {
         this.id = id;
     }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
@@ -40,7 +40,8 @@ public class HashtagEntity {
     public HashtagEntity() {
     }
 
-    public HashtagEntity(PostEntity post, String tag) {
+    public HashtagEntity(Long id, PostEntity post, String tag) {
+        this.id = id;
         this.post = post;
         this.tag = tag;
     }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
@@ -13,8 +13,9 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 import lombok.Getter;
+
+import static com.nexters.phochak.post.domain.Hashtag.HASHTAG_MAX_SIZE;
 
 @Getter
 @Entity
@@ -22,7 +23,6 @@ import lombok.Getter;
         {@Index(name = "idx01_hashtag", columnList = "TAG"),
         @Index(name = "idx02_hashtag", columnList = "POST_ID")})
 public class HashtagEntity {
-    public static final int HASHTAG_MAX_SIZE = 20;
 
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
@@ -40,7 +40,6 @@ public class HashtagEntity {
     public HashtagEntity() {
     }
 
-    @Builder
     public HashtagEntity(PostEntity post, String tag) {
         this.post = post;
         this.tag = tag;

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagEntity.java
@@ -40,7 +40,7 @@ public class HashtagEntity {
     public HashtagEntity() {
     }
 
-    public HashtagEntity(Long id, PostEntity post, String tag) {
+    HashtagEntity(Long id, PostEntity post, String tag) {
         this.id = id;
         this.post = post;
         this.tag = tag;

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
@@ -12,6 +12,7 @@ public class HashtagMapper {
 
     public HashtagEntity toEntity(final Hashtag hashtag) {
         return new HashtagEntity(
+                hashtag.getId(),
                 postMapper.toEntity(hashtag.getPost()),
                 hashtag.getTag());
     }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
@@ -17,8 +17,10 @@ public class HashtagMapper {
     }
 
     public Hashtag toDomain(final HashtagEntity hashtagEntity) {
-        return new Hashtag(
+        final Hashtag hashtag = new Hashtag(
                 postMapper.toDomain(hashtagEntity.getPost()),
                 hashtagEntity.getTag());
+        hashtag.assignId(hashtagEntity.getId());
+        return hashtag;
     }
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/HashtagMapper.java
@@ -18,10 +18,9 @@ public class HashtagMapper {
     }
 
     public Hashtag toDomain(final HashtagEntity hashtagEntity) {
-        final Hashtag hashtag = new Hashtag(
+        return Hashtag.forMapper(
+                hashtagEntity.getId(),
                 postMapper.toDomain(hashtagEntity.getPost()),
                 hashtagEntity.getTag());
-        hashtag.assignId(hashtagEntity.getId());
-        return hashtag;
     }
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesEntity.java
@@ -14,10 +14,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.Getter;
-
-import java.util.Objects;
 
 @Getter
 @Entity
@@ -42,13 +39,8 @@ public class LikesEntity extends BaseTime {
     public LikesEntity() {
     }
 
-    @Builder
     public LikesEntity(UserEntity user, PostEntity post) {
         this.user = user;
         this.post = post;
-    }
-
-    public boolean hasLikesByUser(Long userId) {
-        return Objects.equals(this.user.getId(), userId);
     }
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesEntity.java
@@ -39,7 +39,8 @@ public class LikesEntity extends BaseTime {
     public LikesEntity() {
     }
 
-    public LikesEntity(UserEntity user, PostEntity post) {
+    LikesEntity(final Long id, final UserEntity user, final PostEntity post) {
+        this.id = id;
         this.user = user;
         this.post = post;
     }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
@@ -19,11 +19,10 @@ public class LikesMapper {
     }
 
     public Likes toDomain(LikesEntity likeEntity) {
-        final Likes likes = new Likes(
+        return new Likes(
+                likeEntity.getId(),
                 userMapper.toDomain(likeEntity.getUser()),
                 postMapper.toDomain(likeEntity.getPost()));
-        likes.assignId(likeEntity.getId());
-        return likes;
     }
 
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
@@ -13,13 +13,13 @@ public class LikesMapper {
 
     public LikesEntity toEntity(Likes like) {
         return new LikesEntity(
+                like.getId(),
                 userMapper.toEntity(like.getUser()),
-                postMapper.toEntity(like.getPost())
-        );
+                postMapper.toEntity(like.getPost()));
     }
 
     public Likes toDomain(LikesEntity likeEntity) {
-        return new Likes(
+        return Likes.forMapper(
                 likeEntity.getId(),
                 userMapper.toDomain(likeEntity.getUser()),
                 postMapper.toDomain(likeEntity.getPost()));

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/LikesMapper.java
@@ -19,11 +19,11 @@ public class LikesMapper {
     }
 
     public Likes toDomain(LikesEntity likeEntity) {
-        return new Likes(
-                likeEntity.getId(),
-                postMapper.toDomain(likeEntity.getPost()),
-                userMapper.toDomain(likeEntity.getUser())
-        );
+        final Likes likes = new Likes(
+                userMapper.toDomain(likeEntity.getUser()),
+                postMapper.toDomain(likeEntity.getPost()));
+        likes.assignId(likeEntity.getId());
+        return likes;
     }
 
 }

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostEntity.java
@@ -21,7 +21,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.type.YesNoConverter;
@@ -71,16 +70,6 @@ public class PostEntity extends BaseTime {
 
     public PostEntity() {
     }
-
-    @Builder
-    public PostEntity(UserEntity userEntity, ShortsEntity shorts, PostCategoryEnum postCategory) {
-        this.user = userEntity;
-        this.shorts = shorts;
-        this.postCategory = postCategory;
-        this.isBlind = false;
-        this.view = 0L;
-    }
-
 
     public PostEntity(final Long id, final UserEntity user, final ShortsEntity shorts, final List<ReportPostEntity> reportPostEntity, final Long view, final PostCategoryEnum postCategory, final boolean isBlind) {
         this.id = id;

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/PostMapper.java
@@ -24,7 +24,7 @@ public class PostMapper {
     }
 
     public Post toDomain(PostEntity postEntity) {
-        return new Post(
+        return Post.forMapper(
                 postEntity.getId(),
                 userMapper.toDomain(postEntity.getUser()),
                 shortsMapper.toDomain(postEntity.getShorts()),

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/ReportPostEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/ReportPostEntity.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -38,7 +37,6 @@ public class ReportPostEntity extends BaseTime {
     public ReportPostEntity() {
     }
 
-    @Builder
     public ReportPostEntity(Long id, UserEntity reporter, PostEntity post) {
         this.id = id;
         this.reporter = reporter;

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/ReportPostEntity.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/ReportPostEntity.java
@@ -37,7 +37,7 @@ public class ReportPostEntity extends BaseTime {
     public ReportPostEntity() {
     }
 
-    public ReportPostEntity(Long id, UserEntity reporter, PostEntity post) {
+    ReportPostEntity(Long id, UserEntity reporter, PostEntity post) {
         this.id = id;
         this.reporter = reporter;
         this.post = post;

--- a/src/main/java/com/nexters/phochak/post/adapter/out/persistence/ReportPostMapper.java
+++ b/src/main/java/com/nexters/phochak/post/adapter/out/persistence/ReportPostMapper.java
@@ -16,17 +16,14 @@ public class ReportPostMapper {
         return new ReportPostEntity(
             reportPost.getId(),
             userMapper.toEntity(reportPost.getUser()),
-            postMapper.toEntity(reportPost.getPost())
-        );
+            postMapper.toEntity(reportPost.getPost()));
     }
 
     public ReportPost toDomain(final ReportPostEntity reportPostEntity) {
-        final ReportPost reportPost = new ReportPost(
+        return ReportPost.forMapper(
+                reportPostEntity.getId(),
                 userMapper.toDomain(reportPostEntity.getReporter()),
-                postMapper.toDomain(reportPostEntity.getPost())
-        );
-        reportPost.assignId(reportPostEntity.getId());
-        return reportPost;
+                postMapper.toDomain(reportPostEntity.getPost()));
     }
 
 }

--- a/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
@@ -36,6 +36,16 @@ public class Hashtag {
         }
     }
 
+    private Hashtag(final Long id, final Post post, final String tag) {
+        this.id = id;
+        this.post = post;
+        this.tag = tag;
+    }
+
+    public static Hashtag forMapper(final Long id, final Post post, final String tag) {
+        return new Hashtag(id, post, tag);
+    }
+
     public void assignId(final Long id) {
         this.id = id;
     }

--- a/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Hashtag.java
@@ -35,4 +35,8 @@ public class Hashtag {
             throw new PhochakException(ResCode.INVALID_INPUT, "해시태그 형식이 올바르지 않습니다.");
         }
     }
+
+    public void assignId(final Long id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/com/nexters/phochak/post/domain/Likes.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Likes.java
@@ -1,6 +1,7 @@
 package com.nexters.phochak.post.domain;
 
 import com.nexters.phochak.user.domain.User;
+import io.jsonwebtoken.lang.Assert;
 import lombok.Getter;
 
 @Getter
@@ -10,15 +11,14 @@ public class Likes {
     private final Post post;
 
     public Likes(final User user, final Post post) {
-        this.id = null;
+        validateConstructor(user, post);
         this.user = user;
         this.post = post;
     }
 
-    public Likes(final Long id, final Post post, final User user) {
-        this.id = id;
-        this.user = user;
-        this.post = post;
+    private static void validateConstructor(final User user, final Post post) {
+        Assert.notNull(user, "user must not be null");
+        Assert.notNull(post, "post must not be null");
     }
 
     public void assignId(Long id) {

--- a/src/main/java/com/nexters/phochak/post/domain/Likes.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Likes.java
@@ -16,6 +16,12 @@ public class Likes {
         this.post = post;
     }
 
+    public Likes(final Long id, final User user, final Post post) {
+        this.id = id;
+        this.user = user;
+        this.post = post;
+    }
+
     private static void validateConstructor(final User user, final Post post) {
         Assert.notNull(user, "user must not be null");
         Assert.notNull(post, "post must not be null");

--- a/src/main/java/com/nexters/phochak/post/domain/Likes.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Likes.java
@@ -16,15 +16,19 @@ public class Likes {
         this.post = post;
     }
 
-    public Likes(final Long id, final User user, final Post post) {
+    private static void validateConstructor(final User user, final Post post) {
+        Assert.notNull(user, "user must not be null");
+        Assert.notNull(post, "post must not be null");
+    }
+
+    private Likes(final Long id, final User user, final Post post) {
         this.id = id;
         this.user = user;
         this.post = post;
     }
 
-    private static void validateConstructor(final User user, final Post post) {
-        Assert.notNull(user, "user must not be null");
-        Assert.notNull(post, "post must not be null");
+    public static Likes forMapper(Long id, final User user, final Post post) {
+        return new Likes(id, user, post);
     }
 
     public void assignId(Long id) {

--- a/src/main/java/com/nexters/phochak/post/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Post.java
@@ -32,10 +32,14 @@ public class Post {
     }
 
     public Post(final User user, final PostCategoryEnum postCategory) {
-        Assert.notNull(user, "user must not be null");
-        Assert.notNull(postCategory, "postCategory must not be null");
+        validateConstructor(user, postCategory);
         this.user = user;
         this.postCategory = postCategory;
+    }
+
+    private static void validateConstructor(final User user, final PostCategoryEnum postCategory) {
+        Assert.notNull(user, "user must not be null");
+        Assert.notNull(postCategory, "postCategory must not be null");
     }
 
     public void assignId(final Long id) {

--- a/src/main/java/com/nexters/phochak/post/domain/Post.java
+++ b/src/main/java/com/nexters/phochak/post/domain/Post.java
@@ -21,16 +21,6 @@ public class Post {
     private List<Likes> likes = new ArrayList<>();
     private List<Hashtag> hashtagList = new ArrayList<>();
 
-    public Post(final Long id, final User user, final Shorts shorts, final List<ReportPostEntity> reportPostEntity, final Long view, final PostCategoryEnum postCategory, final boolean isBlind) {
-        this.id = id;
-        this.user = user;
-        this.shorts = shorts;
-        this.reportPostEntity = reportPostEntity;
-        this.view = view;
-        this.postCategory = postCategory;
-        this.isBlind = isBlind;
-    }
-
     public Post(final User user, final PostCategoryEnum postCategory) {
         validateConstructor(user, postCategory);
         this.user = user;
@@ -40,6 +30,27 @@ public class Post {
     private static void validateConstructor(final User user, final PostCategoryEnum postCategory) {
         Assert.notNull(user, "user must not be null");
         Assert.notNull(postCategory, "postCategory must not be null");
+    }
+
+    private Post(final Long id, final User user, final Shorts shorts, final List<ReportPostEntity> reportPostEntity, final Long view, final PostCategoryEnum postCategory, final boolean isBlind) {
+        this.id = id;
+        this.user = user;
+        this.shorts = shorts;
+        this.reportPostEntity = reportPostEntity;
+        this.view = view;
+        this.postCategory = postCategory;
+        this.isBlind = isBlind;
+    }
+
+    public static Post forMapper(
+            final Long id,
+            final User user,
+            final Shorts shorts,
+            final List<ReportPostEntity> reportPostEntity,
+            final Long view,
+            final PostCategoryEnum postCategory,
+            final boolean isBlind) {
+        return new Post(id, user, shorts, reportPostEntity, view, postCategory, isBlind);
     }
 
     public void assignId(final Long id) {

--- a/src/main/java/com/nexters/phochak/post/domain/ReportPost.java
+++ b/src/main/java/com/nexters/phochak/post/domain/ReportPost.java
@@ -22,6 +22,16 @@ public class ReportPost {
         Assert.notNull(post, "post must not be null");
     }
 
+    private ReportPost(final Long id, final User user, final Post post) {
+        this.id = id;
+        this.user = user;
+        this.post = post;
+    }
+
+    public static ReportPost forMapper(final Long id, final User user, final Post post) {
+        return new ReportPost(id, user, post);
+    }
+
     public void assignId(final Long id) {
         this.id = id;
     }

--- a/src/main/java/com/nexters/phochak/post/domain/ReportPost.java
+++ b/src/main/java/com/nexters/phochak/post/domain/ReportPost.java
@@ -2,6 +2,7 @@ package com.nexters.phochak.post.domain;
 
 import com.nexters.phochak.user.domain.User;
 import lombok.Getter;
+import org.springframework.util.Assert;
 
 @Getter
 public class ReportPost {
@@ -11,8 +12,14 @@ public class ReportPost {
     private static final Long BLOCK_CRITERIA = 5L;
 
     public ReportPost(final User user, final Post post) {
+        validateConstructor(user, post);
         this.user = user;
         this.post = post;
+    }
+
+    private static void validateConstructor(final User user, final Post post) {
+        Assert.notNull(user, "user must not be null");
+        Assert.notNull(post, "post must not be null");
     }
 
     public void assignId(final Long id) {

--- a/src/main/java/com/nexters/phochak/shorts/adapter/out/persistence/ShortsEntity.java
+++ b/src/main/java/com/nexters/phochak/shorts/adapter/out/persistence/ShortsEntity.java
@@ -39,7 +39,7 @@ public class ShortsEntity {
     public ShortsEntity() {
     }
 
-    public ShortsEntity(Long id, ShortsStateEnum shortsStateEnum, String uploadKey, String shortsUrl, String thumbnailUrl) {
+    ShortsEntity(Long id, ShortsStateEnum shortsStateEnum, String uploadKey, String shortsUrl, String thumbnailUrl) {
         this.id = id;
         this.shortsStateEnum = shortsStateEnum;
         this.uploadKey = uploadKey;

--- a/src/main/java/com/nexters/phochak/shorts/adapter/out/persistence/ShortsEntity.java
+++ b/src/main/java/com/nexters/phochak/shorts/adapter/out/persistence/ShortsEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.Builder;
 import lombok.Getter;
 
 @Entity
@@ -40,16 +39,11 @@ public class ShortsEntity {
     public ShortsEntity() {
     }
 
-    @Builder
     public ShortsEntity(Long id, ShortsStateEnum shortsStateEnum, String uploadKey, String shortsUrl, String thumbnailUrl) {
         this.id = id;
         this.shortsStateEnum = shortsStateEnum;
         this.uploadKey = uploadKey;
         this.shortsUrl = shortsUrl;
         this.thumbnailUrl = thumbnailUrl;
-    }
-
-    public void updateShortsState(ShortsStateEnum shortsStateEnum) {
-        this.shortsStateEnum = shortsStateEnum;
     }
 }

--- a/src/main/java/com/nexters/phochak/shorts/adapter/out/persistence/ShortsMapper.java
+++ b/src/main/java/com/nexters/phochak/shorts/adapter/out/persistence/ShortsMapper.java
@@ -7,13 +7,12 @@ import org.springframework.stereotype.Component;
 public class ShortsMapper {
 
     public Shorts toDomain(final ShortsEntity shortsEntity) {
-        final Shorts shorts = new Shorts(
+        return Shorts.forMapper(
+                shortsEntity.getId(),
                 shortsEntity.getShortsStateEnum(),
                 shortsEntity.getUploadKey(),
                 shortsEntity.getShortsUrl(),
                 shortsEntity.getThumbnailUrl());
-        shorts.assignId(shortsEntity.getId());
-        return shorts;
     }
 
     public ShortsEntity toEntity(final Shorts shorts) {

--- a/src/main/java/com/nexters/phochak/shorts/domain/Shorts.java
+++ b/src/main/java/com/nexters/phochak/shorts/domain/Shorts.java
@@ -24,6 +24,18 @@ public class Shorts {
         this.thumbnailUrl = thumbnailUrl;
     }
 
+    private Shorts(final Long id, final ShortsStateEnum shortsStateEnum, final String uploadKey, final String shortsUrl, final String thumbnailUrl) {
+        this.id = id;
+        this.shortsStateEnum = shortsStateEnum;
+        this.uploadKey = uploadKey;
+        this.shortsUrl = shortsUrl;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public static Shorts forMapper(final Long id, final ShortsStateEnum shortsStateEnum, final String uploadKey, final String shortsUrl, final String thumbnailUrl) {
+        return new Shorts(id, shortsStateEnum, uploadKey, shortsUrl, thumbnailUrl);
+    }
+
     private static void validateConstructor(final ShortsStateEnum shortsStateEnum, final String uploadKey, final String shortsUrl, final String thumbnailUrl) {
         Assert.notNull(shortsStateEnum, "shortsStateEnum must not be null");
         Assert.notNull(uploadKey, "uploadKey must not be null");

--- a/src/main/java/com/nexters/phochak/shorts/domain/Shorts.java
+++ b/src/main/java/com/nexters/phochak/shorts/domain/Shorts.java
@@ -1,6 +1,7 @@
 package com.nexters.phochak.shorts.domain;
 
 import lombok.Getter;
+import org.springframework.util.Assert;
 
 @Getter
 public class Shorts {
@@ -16,10 +17,18 @@ public class Shorts {
     private String thumbnailUrl;
 
     public Shorts(final ShortsStateEnum shortsStateEnum, final String uploadKey, final String shortsUrl, final String thumbnailUrl) {
+        validateConstructor(shortsStateEnum, uploadKey, shortsUrl, thumbnailUrl);
         this.shortsStateEnum = shortsStateEnum;
         this.uploadKey = uploadKey;
         this.shortsUrl = shortsUrl;
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+    private static void validateConstructor(final ShortsStateEnum shortsStateEnum, final String uploadKey, final String shortsUrl, final String thumbnailUrl) {
+        Assert.notNull(shortsStateEnum, "shortsStateEnum must not be null");
+        Assert.notNull(uploadKey, "uploadKey must not be null");
+        Assert.notNull(shortsUrl, "shortsUrl must not be null");
+        Assert.notNull(thumbnailUrl, "thumbnailUrl must not be null");
     }
 
     public void assignId(final Long id) {

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/CreateUserAdapter.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/CreateUserAdapter.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Component;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.nexters.phochak.user.domain.User.NICKNAME_MAX_SIZE;
+
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -26,12 +28,12 @@ public class CreateUserAdapter implements CreateUserPort {
             return userMapper.toDomain(target.get());
         } else {
             log.info("CreateUserAdapter|getOrCreateUser(신규 회원 가입): {}", userInformation);
-            final UserEntity userEntity = userRepository.save(new UserEntity(
-                            userInformation.getProvider(),
-                            userInformation.getProviderId(),
-                            generateInitialNickname(),
-                            userInformation.getInitialProfileImage()
-                    ));
+            final User user = new User(
+                    userInformation.getProvider(),
+                    userInformation.getProviderId(),
+                    generateInitialNickname(),
+                    userInformation.getInitialProfileImage());
+            final UserEntity userEntity = userRepository.save(userMapper.toEntity(user));
             return userMapper.toDomain(userEntity);
         }
     }
@@ -42,6 +44,6 @@ public class CreateUserAdapter implements CreateUserPort {
     }
 
     private static String generateUUID() {
-        return UUID.randomUUID().toString().replace("-", "").substring(0, UserEntity.NICKNAME_MAX_SIZE - NICKNAME_PREFIX.length());
+        return UUID.randomUUID().toString().replace("-", "").substring(0, NICKNAME_MAX_SIZE - NICKNAME_PREFIX.length());
     }
 }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserEntity.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserEntity.java
@@ -11,7 +11,7 @@ public class IgnoredUserEntity {
     @EmbeddedId
     private IgnoredUserEntityRelation ignoredUserRelation;
 
-    public IgnoredUserEntity(IgnoredUserEntityRelation ignoredUserRelation) {
+    IgnoredUserEntity(IgnoredUserEntityRelation ignoredUserRelation) {
         this.ignoredUserRelation = ignoredUserRelation;
     }
 

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserEntity.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserEntity.java
@@ -2,7 +2,6 @@ package com.nexters.phochak.user.adapter.out.persistence;
 
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -12,7 +11,6 @@ public class IgnoredUserEntity {
     @EmbeddedId
     private IgnoredUserEntityRelation ignoredUserRelation;
 
-    @Builder
     public IgnoredUserEntity(IgnoredUserEntityRelation ignoredUserRelation) {
         this.ignoredUserRelation = ignoredUserRelation;
     }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserEntityRelation.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserEntityRelation.java
@@ -6,7 +6,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,7 +23,6 @@ public class IgnoredUserEntityRelation implements Serializable {
     @JoinColumn(name="IGNORED_USER_ID", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private UserEntity ignoredUser;
 
-    @Builder
     public IgnoredUserEntityRelation(UserEntity user, UserEntity ignoredUser) {
         this.user = user;
         this.ignoredUser = ignoredUser;

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserMapper.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/IgnoredUserMapper.java
@@ -9,7 +9,10 @@ import org.springframework.stereotype.Component;
 public class IgnoredUserMapper {
     private final UserMapper userMapper;
     public IgnoredUser toDomain(final IgnoredUserEntity entity) {
-        return IgnoredUser.toDomain(entity);
+        return new IgnoredUser(
+                userMapper.toDomain(entity.getIgnoredUserRelation().getUser()),
+                userMapper.toDomain(entity.getIgnoredUserRelation().getIgnoredUser())
+        );
     }
 
     public IgnoredUserEntity toEntity(final IgnoredUser domain) {

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/SaveUserAdapter.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/SaveUserAdapter.java
@@ -1,0 +1,20 @@
+package com.nexters.phochak.user.adapter.out.persistence;
+
+import com.nexters.phochak.user.application.port.out.SaveUserPort;
+import com.nexters.phochak.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SaveUserAdapter implements SaveUserPort {
+
+    private final UserMapper userMapper;
+    private final UserRepository userRepository;
+
+    @Override
+    public void save(final User user) {
+        final UserEntity userEntity = userMapper.toEntity(user);
+        userRepository.save(userEntity);
+    }
+}

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UpdateUserNicknameAdapter.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UpdateUserNicknameAdapter.java
@@ -1,9 +1,6 @@
 package com.nexters.phochak.user.adapter.out.persistence;
 
-import com.nexters.phochak.common.exception.PhochakException;
-import com.nexters.phochak.common.exception.ResCode;
 import com.nexters.phochak.user.application.port.out.UpdateUserNicknamePort;
-import com.nexters.phochak.user.domain.User;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -20,11 +17,4 @@ public class UpdateUserNicknameAdapter implements UpdateUserNicknamePort {
         return userRepository.existsByNickname(nickname);
     }
 
-    @Override
-    public void modifyNickname(final User user, final String nickname) {
-        final UserEntity userEntity = userRepository.findById(user.getId())
-                .orElseThrow(() -> new PhochakException(ResCode.NOT_FOUND_USER));
-        userEntity.modifyNickname(nickname);
-        user.updateNickname(nickname);
-    }
 }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
@@ -78,16 +78,4 @@ public class UserEntity extends BaseTime {
     public void modifyNickname(String nickname) {
         this.nickname = nickname;
     }
-
-    public void withdrawInformation() {
-        this.nickname = null;
-        this.providerId = null;
-        this.provider = null;
-        this.profileImgUrl = null;
-        this.leaveDate = LocalDateTime.now();
-    }
-
-    public void block() {
-        this.isBlocked = true;
-    }
 }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
@@ -1,5 +1,6 @@
 package com.nexters.phochak.user.adapter.out.persistence;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.nexters.phochak.common.domain.BaseTime;
 import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
 import com.nexters.phochak.user.domain.OAuthProviderEnum;
@@ -55,7 +56,14 @@ public class UserEntity extends BaseTime {
     public UserEntity() {
     }
 
-    UserEntity(final Long id, final FcmDeviceTokenEntity fcmDeviceToken, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
+    UserEntity(final Long id,
+               final FcmDeviceTokenEntity fcmDeviceToken,
+               final OAuthProviderEnum provider,
+               final String providerId,
+               final String nickname,
+               final String profileImgUrl,
+               final Boolean isBlocked,
+               final LocalDateTime leaveDate) {
         this.id = id;
         this.fcmDeviceToken = fcmDeviceToken;
         this.provider = provider;
@@ -66,4 +74,15 @@ public class UserEntity extends BaseTime {
         this.leaveDate = leaveDate;
     }
 
+    @VisibleForTesting
+    public static UserEntity forTest(final Long id,
+                                final FcmDeviceTokenEntity fcmDeviceToken,
+                                final OAuthProviderEnum provider,
+                                final String providerId,
+                                final String nickname,
+                                final String profileImgUrl,
+                                final Boolean isBlocked,
+                                final LocalDateTime leaveDate) {
+        return new UserEntity(id, fcmDeviceToken, provider, providerId, nickname, profileImgUrl, isBlocked, leaveDate);
+    }
 }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
@@ -1,6 +1,5 @@
 package com.nexters.phochak.user.adapter.out.persistence;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.nexters.phochak.common.domain.BaseTime;
 import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
 import com.nexters.phochak.user.domain.OAuthProviderEnum;
@@ -15,17 +14,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.type.YesNoConverter;
 
 import java.time.LocalDateTime;
 
+import static com.nexters.phochak.user.domain.User.NICKNAME_MAX_SIZE;
+
 @Getter
 @Entity
 @Table(name = "USERS")
 public class UserEntity extends BaseTime {
-    public static final int NICKNAME_MAX_SIZE = 10;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "USER_ID")
@@ -55,8 +55,6 @@ public class UserEntity extends BaseTime {
     public UserEntity() {
     }
 
-    @Builder //TODO: 기존 테스트 삭제 이후 빌더 제거
-    @VisibleForTesting
     public UserEntity(final Long id, final FcmDeviceTokenEntity fcmDeviceToken, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
         this.id = id;
         this.fcmDeviceToken = fcmDeviceToken;
@@ -73,9 +71,5 @@ public class UserEntity extends BaseTime {
         this.providerId = providerId;
         this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
-    }
-
-    public void modifyNickname(String nickname) {
-        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserEntity.java
@@ -55,7 +55,7 @@ public class UserEntity extends BaseTime {
     public UserEntity() {
     }
 
-    public UserEntity(final Long id, final FcmDeviceTokenEntity fcmDeviceToken, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
+    UserEntity(final Long id, final FcmDeviceTokenEntity fcmDeviceToken, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
         this.id = id;
         this.fcmDeviceToken = fcmDeviceToken;
         this.provider = provider;
@@ -66,10 +66,4 @@ public class UserEntity extends BaseTime {
         this.leaveDate = leaveDate;
     }
 
-    public UserEntity(OAuthProviderEnum provider, String providerId, String nickname, String profileImgUrl) {
-        this.provider = provider;
-        this.providerId = providerId;
-        this.nickname = nickname;
-        this.profileImgUrl = profileImgUrl;
-    }
 }

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserMapper.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserMapper.java
@@ -7,8 +7,19 @@ import org.springframework.stereotype.Component;
 public class UserMapper {
 
     public User toDomain(final UserEntity userEntity) {
-        return User.toDomain(userEntity);
+        final User user = new User(
+                userEntity.getFcmDeviceToken(),
+                userEntity.getProvider(),
+                userEntity.getProviderId(),
+                userEntity.getNickname(),
+                userEntity.getProfileImgUrl(),
+                userEntity.getIsBlocked(),
+                userEntity.getLeaveDate()
+        );
+        user.assignId(userEntity.getId());
+        return user;
     }
+
     public UserEntity toEntity(final User user) {
         return new UserEntity(
                 user.getId(),

--- a/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserMapper.java
+++ b/src/main/java/com/nexters/phochak/user/adapter/out/persistence/UserMapper.java
@@ -7,7 +7,8 @@ import org.springframework.stereotype.Component;
 public class UserMapper {
 
     public User toDomain(final UserEntity userEntity) {
-        final User user = new User(
+        return User.forMapper(
+                userEntity.getId(),
                 userEntity.getFcmDeviceToken(),
                 userEntity.getProvider(),
                 userEntity.getProviderId(),
@@ -16,8 +17,6 @@ public class UserMapper {
                 userEntity.getIsBlocked(),
                 userEntity.getLeaveDate()
         );
-        user.assignId(userEntity.getId());
-        return user;
     }
 
     public UserEntity toEntity(final User user) {

--- a/src/main/java/com/nexters/phochak/user/application/UserService.java
+++ b/src/main/java/com/nexters/phochak/user/application/UserService.java
@@ -14,6 +14,7 @@ import com.nexters.phochak.user.application.port.out.FindIgnoredUserPort;
 import com.nexters.phochak.user.application.port.out.FindUserPort;
 import com.nexters.phochak.user.application.port.out.NotificationTokenRegisterPort;
 import com.nexters.phochak.user.application.port.out.OAuthRequestPort;
+import com.nexters.phochak.user.application.port.out.SaveUserPort;
 import com.nexters.phochak.user.application.port.out.UpdateUserNicknamePort;
 import com.nexters.phochak.user.domain.OAuthProviderEnum;
 import com.nexters.phochak.user.domain.User;
@@ -37,6 +38,7 @@ public class UserService implements UserUseCase {
     private final NotificationTokenRegisterPort notificationTokenRegisterPort;
     private final WithdrawUserPort withdrawUserPort;
     private final DeleteAllPostPort deleteAllPostPort;
+    private final SaveUserPort saveUserPort;
 
     @Override
     public Long login(final String provider, final LoginRequestDto requestDto) {
@@ -56,13 +58,13 @@ public class UserService implements UserUseCase {
 
 
     @Override
-    @Transactional
     public void modifyNickname(final Long userId, final String nickname) {
         if (updateUserNicknamePort.checkDuplicatedNickname(nickname)) {
             throw new PhochakException(ResCode.DUPLICATED_NICKNAME);
         }
         User user = findUserPort.load(userId);
-        updateUserNicknamePort.modifyNickname(user, nickname);
+        user.modifyNickname(nickname);
+        saveUserPort.save(user);
     }
 
     @Override

--- a/src/main/java/com/nexters/phochak/user/application/port/out/SaveUserPort.java
+++ b/src/main/java/com/nexters/phochak/user/application/port/out/SaveUserPort.java
@@ -1,0 +1,7 @@
+package com.nexters.phochak.user.application.port.out;
+
+import com.nexters.phochak.user.domain.User;
+
+public interface SaveUserPort {
+    void save(User user);
+}

--- a/src/main/java/com/nexters/phochak/user/application/port/out/UpdateUserNicknamePort.java
+++ b/src/main/java/com/nexters/phochak/user/application/port/out/UpdateUserNicknamePort.java
@@ -1,9 +1,6 @@
 package com.nexters.phochak.user.application.port.out;
 
-import com.nexters.phochak.user.domain.User;
-
 public interface UpdateUserNicknamePort {
     boolean checkDuplicatedNickname(String nickname);
 
-    void modifyNickname(final User user, String nickname);
 }

--- a/src/main/java/com/nexters/phochak/user/domain/IgnoredUser.java
+++ b/src/main/java/com/nexters/phochak/user/domain/IgnoredUser.java
@@ -1,6 +1,5 @@
 package com.nexters.phochak.user.domain;
 
-import com.nexters.phochak.user.adapter.out.persistence.IgnoredUserEntity;
 import lombok.Getter;
 
 @Getter
@@ -13,10 +12,4 @@ public class IgnoredUser {
         this.ignoredUser = ignoredUser;
     }
 
-    public static IgnoredUser toDomain(final IgnoredUserEntity entity) {
-        return new IgnoredUser(
-                User.toDomain(entity.getIgnoredUserRelation().getUser()),
-                User.toDomain(entity.getIgnoredUserRelation().getIgnoredUser())
-        );
-    }
 }

--- a/src/main/java/com/nexters/phochak/user/domain/IgnoredUser.java
+++ b/src/main/java/com/nexters/phochak/user/domain/IgnoredUser.java
@@ -1,6 +1,7 @@
 package com.nexters.phochak.user.domain;
 
 import lombok.Getter;
+import org.springframework.util.Assert;
 
 @Getter
 public class IgnoredUser {
@@ -8,8 +9,14 @@ public class IgnoredUser {
     private final User ignoredUser;
 
     public IgnoredUser(final User user, final User ignoredUser) {
+        validateConstructor(user, ignoredUser);
         this.user = user;
         this.ignoredUser = ignoredUser;
+    }
+
+    private static void validateConstructor(final User user, final User ignoredUser) {
+        Assert.notNull(user, "user must not be null");
+        Assert.notNull(ignoredUser, "ignoredUser must not be null");
     }
 
 }

--- a/src/main/java/com/nexters/phochak/user/domain/User.java
+++ b/src/main/java/com/nexters/phochak/user/domain/User.java
@@ -3,6 +3,7 @@ package com.nexters.phochak.user.domain;
 import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.springframework.util.Assert;
 
 import java.time.LocalDateTime;
 
@@ -18,6 +19,26 @@ public class User {
     private Boolean isBlocked;
     private LocalDateTime leaveDate;
 
+    public static final int NICKNAME_MAX_SIZE = 10;
+
+    public User(OAuthProviderEnum provider, String providerId, String nickname, String profileImgUrl) {
+        validateConstructor(provider, providerId, nickname, profileImgUrl);
+        this.provider = provider;
+        this.providerId = providerId;
+        this.nickname = nickname;
+        this.profileImgUrl = profileImgUrl;
+    }
+
+    private static void validateConstructor(final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl) {
+        Assert.notNull(provider, "provider must not be null");
+        Assert.notNull(providerId, "providerId must not be null");
+        Assert.notNull(nickname, "nickname must not be null");
+        if (nickname.length() > 10) {
+            throw new IllegalArgumentException("nickname must be less than 10 characters");
+        }
+        Assert.notNull(profileImgUrl, "profileImgUrl must not be null");
+    }
+
     public User(final FcmDeviceTokenEntity fcmDeviceTokenEntity, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
         this.fcmDeviceTokenEntity = fcmDeviceTokenEntity;
         this.provider = provider;
@@ -30,10 +51,6 @@ public class User {
 
     public void assignId(Long generatedId) {
         this.id = generatedId;
-    }
-
-    public void updateNickname(final String nickname) {
-        this.nickname = nickname;
     }
 
     public void withdraw() {

--- a/src/main/java/com/nexters/phochak/user/domain/User.java
+++ b/src/main/java/com/nexters/phochak/user/domain/User.java
@@ -39,7 +39,8 @@ public class User {
         Assert.notNull(profileImgUrl, "profileImgUrl must not be null");
     }
 
-    public User(final FcmDeviceTokenEntity fcmDeviceTokenEntity, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
+    private User(final Long id, final FcmDeviceTokenEntity fcmDeviceTokenEntity, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
+        this.id = id;
         this.fcmDeviceTokenEntity = fcmDeviceTokenEntity;
         this.provider = provider;
         this.providerId = providerId;
@@ -47,6 +48,18 @@ public class User {
         this.profileImgUrl = profileImgUrl;
         this.isBlocked = isBlocked;
         this.leaveDate = leaveDate;
+    }
+
+    public static User forMapper(
+            final Long id,
+            final FcmDeviceTokenEntity fcmDeviceTokenEntity,
+            final OAuthProviderEnum provider,
+            final String providerId,
+            final String nickname,
+            final String profileImgUrl,
+            final Boolean isBlocked,
+            final LocalDateTime leaveDate) {
+        return new User(id, fcmDeviceTokenEntity, provider, providerId, nickname, profileImgUrl, isBlocked, leaveDate);
     }
 
     public void assignId(Long generatedId) {

--- a/src/main/java/com/nexters/phochak/user/domain/User.java
+++ b/src/main/java/com/nexters/phochak/user/domain/User.java
@@ -1,7 +1,6 @@
 package com.nexters.phochak.user.domain;
 
 import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -29,31 +28,8 @@ public class User {
         this.leaveDate = leaveDate;
     }
 
-    public User(final Long id, final FcmDeviceTokenEntity fcmDeviceTokenEntity, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {
-        this.id = id;
-        this.fcmDeviceTokenEntity = fcmDeviceTokenEntity;
-        this.provider = provider;
-        this.providerId = providerId;
-        this.nickname = nickname;
-        this.profileImgUrl = profileImgUrl;
-        this.isBlocked = isBlocked;
-        this.leaveDate = leaveDate;
-    }
-
     public void assignId(Long generatedId) {
         this.id = generatedId;
-    }
-
-    public static User toDomain(UserEntity userEntity) {
-        return new User(
-                userEntity.getId(),
-                userEntity.getFcmDeviceToken(),
-                userEntity.getProvider(),
-                userEntity.getProviderId(),
-                userEntity.getNickname(),
-                userEntity.getProfileImgUrl(),
-                userEntity.getIsBlocked(),
-                userEntity.getLeaveDate());
     }
 
     public void updateNickname(final String nickname) {

--- a/src/main/java/com/nexters/phochak/user/domain/User.java
+++ b/src/main/java/com/nexters/phochak/user/domain/User.java
@@ -27,6 +27,7 @@ public class User {
         this.providerId = providerId;
         this.nickname = nickname;
         this.profileImgUrl = profileImgUrl;
+        isBlocked = false;
     }
 
     private static void validateConstructor(final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl) {
@@ -36,7 +37,6 @@ public class User {
         if (nickname.length() > 10) {
             throw new IllegalArgumentException("nickname must be less than 10 characters");
         }
-        Assert.notNull(profileImgUrl, "profileImgUrl must not be null");
     }
 
     private User(final Long id, final FcmDeviceTokenEntity fcmDeviceTokenEntity, final OAuthProviderEnum provider, final String providerId, final String nickname, final String profileImgUrl, final Boolean isBlocked, final LocalDateTime leaveDate) {

--- a/src/main/java/com/nexters/phochak/user/domain/User.java
+++ b/src/main/java/com/nexters/phochak/user/domain/User.java
@@ -43,4 +43,8 @@ public class User {
         this.profileImgUrl = null;
         this.leaveDate = LocalDateTime.now();
     }
+
+    public void modifyNickname(final String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/test/java/com/nexters/phochak/common/CreateUserQuery.java
+++ b/src/test/java/com/nexters/phochak/common/CreateUserQuery.java
@@ -60,7 +60,7 @@ public class CreateUserQuery {
     }
 
     public Scenario.NextScenarioStep request() throws Exception {
-        UserEntity user = new UserEntity(
+        UserEntity user = UserEntity.forTest(
                 id,
                 fcmDeviceToken,
                 provider,

--- a/src/test/java/com/nexters/phochak/deprecated/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/AuthIntegrationTest.java
@@ -1,296 +1,296 @@
-package com.nexters.phochak.deprecated.integration;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nexters.phochak.common.docs.RestDocs;
-import com.nexters.phochak.common.exception.CustomExceptionHandler;
-import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
-import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
-import com.nexters.phochak.post.domain.PostCategoryEnum;
-import com.nexters.phochak.shorts.adapter.out.api.NCPStorageClient;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsRepository;
-import com.nexters.phochak.user.adapter.in.web.UserController;
-import com.nexters.phochak.user.adapter.out.persistence.RefreshTokenRepository;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import com.nexters.phochak.user.application.port.in.JwtTokenUseCase;
-import com.nexters.phochak.user.application.port.in.LogoutRequestDto;
-import com.nexters.phochak.user.application.port.in.ReissueTokenRequestDto;
-import com.nexters.phochak.user.application.port.in.WithdrawRequestDto;
-import com.nexters.phochak.user.domain.OAuthProviderEnum;
-import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static com.nexters.phochak.auth.AuthAspect.AUTHORIZATION_HEADER;
-import static com.nexters.phochak.common.exception.ResCode.*;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@Disabled
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@ActiveProfiles("test")
-@Transactional
-public class AuthIntegrationTest extends RestDocs {
-
-    @Autowired UserController userController;
-    @Autowired UserRepository userRepository;
-    @Autowired PostRepository postRepository;
-    @Autowired ShortsRepository shortsRepository;
-    @Autowired HashtagRepository hashtagRepository;
-    @Autowired
-    JwtTokenUseCase jwtTokenUseCase;
-    @Autowired ObjectMapper objectMapper;
-    @Autowired EntityManager em;
-    @Autowired RefreshTokenRepository refreshTokenRepository;
-    @MockBean NCPStorageClient ncpStorageClient;
-    MockMvc mockMvc;
-    static Long globalUserId;
-
-    @BeforeEach
-    void setUp(RestDocumentationContextProvider restDocumentation) {
-        this.mockMvc = getMockMvcBuilder(restDocumentation, userController)
-                .setControllerAdvice(CustomExceptionHandler.class)
-                .build();
-        UserEntity userEntity = UserEntity.builder()
-                .providerId("1234")
-                .provider(OAuthProviderEnum.KAKAO)
-                .nickname("nickname")
-                .profileImgUrl(null)
-                .build();
-        userRepository.save(userEntity);
-        globalUserId = userEntity.getId();
-    }
-
-    private static String createTokenStringForResponse(JwtTokenUseCase.TokenVo accessToken) {
-        return JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + accessToken.getTokenString();
-    }
-
-    @Test
-    @DisplayName("토큰 재발급 API - 재발급 성공")
-    void reissueToken() throws Exception {
-        //given
-        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, -1000L);
-        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
-
-        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
-
-        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
-                        createTokenStringForResponse(currentAT),
-                        createTokenStringForResponse(currentRT));
-
-        //when, then
-        mockMvc.perform(post("/v1/user/reissue-token")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                    .andDo(document("user/reissue-token/",
-                    preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    requestFields(
-                            fieldWithPath("accessToken").description("(필수) 만료된 Access token"),
-                            fieldWithPath("refreshToken").description("(필수) 만료되지 않은 Refresh token")
-                    ),
-                    responseFields(
-                            fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                            fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                            fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("access token"),
-                            fieldWithPath("data.expiresIn").type(JsonFieldType.STRING).description("access token 유효기간(ms)"),
-                            fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("refresh token"),
-                            fieldWithPath("data.refreshTokenExpiresIn").type(JsonFieldType.STRING).description("refresh token 유효기간(ms)")
-                    )
-            ));
-    }
-
-    @Test
-    @DisplayName("토큰 재발급 API - Refresh Token이 만료된 경우, Expired Token 예외가 발생한다")
-    void reissueToken_RTExpired_InvalidToken() throws Exception {
-        //given
-        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, -2000L);
-        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, -1000L);
-
-        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
-
-        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
-                createTokenStringForResponse(currentAT),
-                createTokenStringForResponse(currentRT));
-
-        //when, then
-        mockMvc.perform(post("/v1/user/reissue-token")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(EXPIRED_TOKEN.getCode()));
-    }
-
-    @Test
-    @DisplayName("토큰 재발급 API - Access Token이 아직 만료되지 않은 경우, 탈취로 간주하고 Invalid Token 예외가 발생한다")
-    void reissueToken_ATNotExpired_InvalidToken() throws Exception {
-        //given
-        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
-        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
-
-        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
-
-        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
-                createTokenStringForResponse(currentAT),
-                createTokenStringForResponse(currentRT));
-
-        //when, then
-        mockMvc.perform(post("/v1/user/reissue-token")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_TOKEN.getCode()));
-    }
-
-    @Test
-    @DisplayName("토큰 재발급 API - AT와 RT가 매치되지 않는 경우, 탈취로 간주하고 Invalid Token 예외가 발생한다")
-    void reissueToken_ATRTNotMatched_InvalidToken() throws Exception {
-        //given
-        JwtTokenUseCase.TokenVo currentAT1 = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
-        JwtTokenUseCase.TokenVo currentRT1 = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
-
-        refreshTokenRepository.saveWithAccessToken(currentRT1.getTokenString(), currentAT1.getTokenString());
-
-        JwtTokenUseCase.TokenVo currentAT2 = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
-        JwtTokenUseCase.TokenVo currentRT2 = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
-
-        refreshTokenRepository.saveWithAccessToken(currentRT2.getTokenString(), currentAT2.getTokenString());
-
-
-        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
-                createTokenStringForResponse(currentAT1),
-                createTokenStringForResponse(currentRT2));
-
-        //when, then
-        mockMvc.perform(post("/v1/user/reissue-token")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_TOKEN.getCode()));
-    }
-
-    @Test
-    @DisplayName("로그아웃 API - 로그아웃 성공")
-    void logout_success() throws Exception {
-        //given
-        JwtTokenUseCase.TokenVo currentAT1 = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
-        JwtTokenUseCase.TokenVo currentRT1 = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
-
-        refreshTokenRepository.saveWithAccessToken(currentRT1.getTokenString(), currentAT1.getTokenString());
-
-        LogoutRequestDto body = new LogoutRequestDto("Bearer " + currentRT1.getTokenString());
-
-        //when, then
-        mockMvc.perform(post("/v1/user/logout")
-                        .header(AUTHORIZATION_HEADER, JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + currentAT1.getTokenString())
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                .andDo(document("user/logout",
-                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("refreshToken").description("(필수) 만료되지 않은 Refresh token")
-                        ),
-                        responseFields(
-                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
-                        )));
-    }
-
-    @Test
-    @DisplayName("회원탈퇴 API - 회원탈퇴 성공")
-    void withdraw_success() throws Exception {
-        //given
-        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
-        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
-
-        UserEntity userEntity = userRepository.findById(globalUserId).get();
-
-        for (int i=0; i < 10; i++) {
-            ShortsEntity shortsEntity = ShortsEntity.builder()
-                    .thumbnailUrl("test" + i)
-                    .shortsUrl("test" + i)
-                    .uploadKey("test" + i)
-                    .build();
-            shortsRepository.save(shortsEntity);
-
-            PostEntity postEntity = PostEntity.builder()
-                    .shorts(shortsEntity)
-                    .postCategory(PostCategoryEnum.TOUR)
-                    .userEntity(userEntity)
-                    .build();
-            postRepository.save(postEntity);
-
-            List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
-            hashtagRepository.saveAll(hashtagEntities);
-        }
-
-        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
-
-        WithdrawRequestDto body = new WithdrawRequestDto("Bearer " + currentRT.getTokenString());
-
-        //when, then
-        mockMvc.perform(post("/v1/user/withdraw")
-                        .header(AUTHORIZATION_HEADER, JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + currentAT.getTokenString())
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                .andDo(document("user/withdraw",
-                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestHeaders(
-                                headerWithName(AUTHORIZATION_HEADER)
-                                        .description("JWT Access Token")
-                        ),
-                        requestFields(
-                                fieldWithPath("refreshToken").description("(필수) 만료되지 않은 Refresh token")
-                        ),
-                        responseFields(
-                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
-                        )));
-
-        em.flush();
-        em.clear();
-
-        Assertions.assertThat(userRepository.findById(globalUserId).get().getNickname()).isNull();
-        Assertions.assertThat(postRepository.count()).isZero();
-        Assertions.assertThat(shortsRepository.count()).isZero();
-        Assertions.assertThat(hashtagRepository.count()).isZero();
-    }
-
-}
+//package com.nexters.phochak.deprecated.integration;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.nexters.phochak.common.docs.RestDocs;
+//import com.nexters.phochak.common.exception.CustomExceptionHandler;
+//import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
+//import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
+//import com.nexters.phochak.post.domain.PostCategoryEnum;
+//import com.nexters.phochak.shorts.adapter.out.api.NCPStorageClient;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsRepository;
+//import com.nexters.phochak.user.adapter.in.web.UserController;
+//import com.nexters.phochak.user.adapter.out.persistence.RefreshTokenRepository;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import com.nexters.phochak.user.application.port.in.JwtTokenUseCase;
+//import com.nexters.phochak.user.application.port.in.LogoutRequestDto;
+//import com.nexters.phochak.user.application.port.in.ReissueTokenRequestDto;
+//import com.nexters.phochak.user.application.port.in.WithdrawRequestDto;
+//import com.nexters.phochak.user.domain.OAuthProviderEnum;
+//import jakarta.persistence.EntityManager;
+//import org.assertj.core.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.http.MediaType;
+//import org.springframework.restdocs.RestDocumentationContextProvider;
+//import org.springframework.restdocs.payload.JsonFieldType;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.util.List;
+//
+//import static com.nexters.phochak.auth.AuthAspect.AUTHORIZATION_HEADER;
+//import static com.nexters.phochak.common.exception.ResCode.*;
+//import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+//import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+//import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+//import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@Disabled
+//@SpringBootTest
+//@AutoConfigureMockMvc
+//@AutoConfigureRestDocs
+//@ActiveProfiles("test")
+//@Transactional
+//public class AuthIntegrationTest extends RestDocs {
+//
+//    @Autowired UserController userController;
+//    @Autowired UserRepository userRepository;
+//    @Autowired PostRepository postRepository;
+//    @Autowired ShortsRepository shortsRepository;
+//    @Autowired HashtagRepository hashtagRepository;
+//    @Autowired
+//    JwtTokenUseCase jwtTokenUseCase;
+//    @Autowired ObjectMapper objectMapper;
+//    @Autowired EntityManager em;
+//    @Autowired RefreshTokenRepository refreshTokenRepository;
+//    @MockBean NCPStorageClient ncpStorageClient;
+//    MockMvc mockMvc;
+//    static Long globalUserId;
+//
+//    @BeforeEach
+//    void setUp(RestDocumentationContextProvider restDocumentation) {
+//        this.mockMvc = getMockMvcBuilder(restDocumentation, userController)
+//                .setControllerAdvice(CustomExceptionHandler.class)
+//                .build();
+//        UserEntity userEntity = UserEntity.builder()
+//                .providerId("1234")
+//                .provider(OAuthProviderEnum.KAKAO)
+//                .nickname("nickname")
+//                .profileImgUrl(null)
+//                .build();
+//        userRepository.save(userEntity);
+//        globalUserId = userEntity.getId();
+//    }
+//
+//    private static String createTokenStringForResponse(JwtTokenUseCase.TokenVo accessToken) {
+//        return JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + accessToken.getTokenString();
+//    }
+//
+//    @Test
+//    @DisplayName("토큰 재발급 API - 재발급 성공")
+//    void reissueToken() throws Exception {
+//        //given
+//        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, -1000L);
+//        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
+//
+//        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
+//                        createTokenStringForResponse(currentAT),
+//                        createTokenStringForResponse(currentRT));
+//
+//        //when, then
+//        mockMvc.perform(post("/v1/user/reissue-token")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                    .andExpect(status().isOk())
+//                    .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                    .andDo(document("user/reissue-token/",
+//                    preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+//                    preprocessResponse(prettyPrint()),
+//                    requestFields(
+//                            fieldWithPath("accessToken").description("(필수) 만료된 Access token"),
+//                            fieldWithPath("refreshToken").description("(필수) 만료되지 않은 Refresh token")
+//                    ),
+//                    responseFields(
+//                            fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                            fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                            fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("access token"),
+//                            fieldWithPath("data.expiresIn").type(JsonFieldType.STRING).description("access token 유효기간(ms)"),
+//                            fieldWithPath("data.refreshToken").type(JsonFieldType.STRING).description("refresh token"),
+//                            fieldWithPath("data.refreshTokenExpiresIn").type(JsonFieldType.STRING).description("refresh token 유효기간(ms)")
+//                    )
+//            ));
+//    }
+//
+//    @Test
+//    @DisplayName("토큰 재발급 API - Refresh Token이 만료된 경우, Expired Token 예외가 발생한다")
+//    void reissueToken_RTExpired_InvalidToken() throws Exception {
+//        //given
+//        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, -2000L);
+//        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, -1000L);
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
+//
+//        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
+//                createTokenStringForResponse(currentAT),
+//                createTokenStringForResponse(currentRT));
+//
+//        //when, then
+//        mockMvc.perform(post("/v1/user/reissue-token")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(EXPIRED_TOKEN.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("토큰 재발급 API - Access Token이 아직 만료되지 않은 경우, 탈취로 간주하고 Invalid Token 예외가 발생한다")
+//    void reissueToken_ATNotExpired_InvalidToken() throws Exception {
+//        //given
+//        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
+//        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
+//
+//        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
+//                createTokenStringForResponse(currentAT),
+//                createTokenStringForResponse(currentRT));
+//
+//        //when, then
+//        mockMvc.perform(post("/v1/user/reissue-token")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_TOKEN.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("토큰 재발급 API - AT와 RT가 매치되지 않는 경우, 탈취로 간주하고 Invalid Token 예외가 발생한다")
+//    void reissueToken_ATRTNotMatched_InvalidToken() throws Exception {
+//        //given
+//        JwtTokenUseCase.TokenVo currentAT1 = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
+//        JwtTokenUseCase.TokenVo currentRT1 = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT1.getTokenString(), currentAT1.getTokenString());
+//
+//        JwtTokenUseCase.TokenVo currentAT2 = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
+//        JwtTokenUseCase.TokenVo currentRT2 = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT2.getTokenString(), currentAT2.getTokenString());
+//
+//
+//        ReissueTokenRequestDto body = new ReissueTokenRequestDto(
+//                createTokenStringForResponse(currentAT1),
+//                createTokenStringForResponse(currentRT2));
+//
+//        //when, then
+//        mockMvc.perform(post("/v1/user/reissue-token")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_TOKEN.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("로그아웃 API - 로그아웃 성공")
+//    void logout_success() throws Exception {
+//        //given
+//        JwtTokenUseCase.TokenVo currentAT1 = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
+//        JwtTokenUseCase.TokenVo currentRT1 = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT1.getTokenString(), currentAT1.getTokenString());
+//
+//        LogoutRequestDto body = new LogoutRequestDto("Bearer " + currentRT1.getTokenString());
+//
+//        //when, then
+//        mockMvc.perform(post("/v1/user/logout")
+//                        .header(AUTHORIZATION_HEADER, JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + currentAT1.getTokenString())
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                .andDo(document("user/logout",
+//                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        requestFields(
+//                                fieldWithPath("refreshToken").description("(필수) 만료되지 않은 Refresh token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
+//                        )));
+//    }
+//
+//    @Test
+//    @DisplayName("회원탈퇴 API - 회원탈퇴 성공")
+//    void withdraw_success() throws Exception {
+//        //given
+//        JwtTokenUseCase.TokenVo currentAT = jwtTokenUseCase.generateToken(globalUserId, 1000000000L);
+//        JwtTokenUseCase.TokenVo currentRT = jwtTokenUseCase.generateToken(globalUserId, 9999999999L);
+//
+//        UserEntity userEntity = userRepository.findById(globalUserId).get();
+//
+//        for (int i=0; i < 10; i++) {
+//            ShortsEntity shortsEntity = ShortsEntity.builder()
+//                    .thumbnailUrl("test" + i)
+//                    .shortsUrl("test" + i)
+//                    .uploadKey("test" + i)
+//                    .build();
+//            shortsRepository.save(shortsEntity);
+//
+//            PostEntity postEntity = PostEntity.builder()
+//                    .shorts(shortsEntity)
+//                    .postCategory(PostCategoryEnum.TOUR)
+//                    .userEntity(userEntity)
+//                    .build();
+//            postRepository.save(postEntity);
+//
+//            List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
+//            hashtagRepository.saveAll(hashtagEntities);
+//        }
+//
+//        refreshTokenRepository.saveWithAccessToken(currentRT.getTokenString(), currentAT.getTokenString());
+//
+//        WithdrawRequestDto body = new WithdrawRequestDto("Bearer " + currentRT.getTokenString());
+//
+//        //when, then
+//        mockMvc.perform(post("/v1/user/withdraw")
+//                        .header(AUTHORIZATION_HEADER, JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + currentAT.getTokenString())
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                .andDo(document("user/withdraw",
+//                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        requestHeaders(
+//                                headerWithName(AUTHORIZATION_HEADER)
+//                                        .description("JWT Access Token")
+//                        ),
+//                        requestFields(
+//                                fieldWithPath("refreshToken").description("(필수) 만료되지 않은 Refresh token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
+//                        )));
+//
+//        em.flush();
+//        em.clear();
+//
+//        Assertions.assertThat(userRepository.findById(globalUserId).get().getNickname()).isNull();
+//        Assertions.assertThat(postRepository.count()).isZero();
+//        Assertions.assertThat(shortsRepository.count()).isZero();
+//        Assertions.assertThat(hashtagRepository.count()).isZero();
+//    }
+//
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/integration/PostLocalStorageIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/PostLocalStorageIntegrationTest.java
@@ -1,157 +1,157 @@
-package com.nexters.phochak.deprecated.integration;
-
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import com.nexters.phochak.user.application.JwtTokenService;
-import com.nexters.phochak.user.application.port.in.JwtTokenUseCase;
-import com.nexters.phochak.user.domain.OAuthProviderEnum;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-
-import java.io.FileInputStream;
-
-import static com.nexters.phochak.auth.AuthAspect.AUTHORIZATION_HEADER;
-import static com.nexters.phochak.common.exception.ResCode.INVALID_INPUT;
-import static com.nexters.phochak.common.exception.ResCode.OK;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@ActiveProfiles("test")
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Disabled
-public class PostLocalStorageIntegrationTest {
-
-    @Autowired UserRepository userRepository;
-    @Autowired
-    JwtTokenService jwtTokenService;
-    @Autowired MockMvc mockMvc;
-
-    static String testToken;
-
-    @BeforeAll
-    void setUp() {
-        UserEntity userEntity = UserEntity.builder()
-                        .providerId("1234")
-                        .provider(OAuthProviderEnum.KAKAO)
-                        .nickname("nickname")
-                        .profileImgUrl(null)
-                        .build();
-        userRepository.save(userEntity);
-        JwtTokenUseCase.TokenVo tokenDto = jwtTokenService.generateToken(userEntity.getId(), 999999999L);
-        testToken = JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + tokenDto.getTokenString();
-    }
-
-    @Test
-    @DisplayName("게시글 생성 성공")
-    void createPost_success() throws Exception {
-        // given
-        MockMultipartFile testVideo = new MockMultipartFile(
-                "shorts",
-                "test.mov",
-                "video/mov",
-                new FileInputStream("app-resource/test/dummy/test.mov"));
-
-        // when, then
-        mockMvc.perform(multipart("/v1/post")
-                .file(testVideo)
-                .param("postCategory", "RESTAURANT")
-                .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
-                .header(AUTHORIZATION_HEADER, testToken)
-        ).andExpect(status().isOk())
-        .andExpect(jsonPath("$.status.resCode").value(OK.getCode()));
-    }
-
-    @Test
-    @DisplayName("게시글 작성 필수 파라미터가 없는 경우 INVALID_INPUT 예외가 발생한다")
-    void createPostValidateEssentialParameter_InvalidInput() throws Exception {
-        // given
-        MockMultipartFile testVideo = new MockMultipartFile(
-                "shorts",
-                "test.mov",
-                "video/mov",
-                new FileInputStream("app-resource/test/dummy/test.mov"));
-
-        // when, then
-        mockMvc.perform(multipart("/v1/post")
-                        .param("postCategory", "RESTAURANT")
-                        .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-
-        mockMvc.perform(multipart("/v1/post")
-                        .file(testVideo)
-                        .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-
-        mockMvc.perform(multipart("/v1/post")
-                        .file(testVideo)
-                        .param("postCategory", "RESTAURANT")
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 카테고리 입력 시에 INVALID_INPUT 예외가 발생한다")
-    void createPostValidateCategory_InvalidInput() throws Exception {
-        // given
-        MockMultipartFile testVideo = new MockMultipartFile(
-                "shorts",
-                "test.mov",
-                "video/mov",
-                new FileInputStream("app-resource/test/dummy/test.mov"));
-
-        // when, then
-        mockMvc.perform(multipart("/v1/post")
-                        .file(testVideo)
-                        .param("postCategory", "INVALIDCATEGORY")
-                        .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-    }
-
-    @Test
-    @DisplayName("해시태그의 개수가 30개가 넘으면, INVALID_INPUT 예외가 발생한다")
-    void HashtagOver30_InvalidInput() throws Exception {
-        // given
-        MockMultipartFile testVideo = new MockMultipartFile(
-                "shorts",
-                "test.mov",
-                "video/mov",
-                new FileInputStream("app-resource/test/dummy/test.mov"));
-
-        StringBuilder hashtagStringList = new StringBuilder("[");
-        for(int i=0;i<31;i++) {
-            hashtagStringList.append("\"해시태그").append(i).append("\",");
-        }
-        hashtagStringList.deleteCharAt(hashtagStringList.length() - 1);
-        hashtagStringList.append("]");
-
-        // when, then
-        mockMvc.perform(multipart("/v1/post")
-                        .file(testVideo)
-                        .param("postCategory", "RESTAURANT")
-                        .param("hashtags", hashtagStringList.toString())
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-    }
-}
+//package com.nexters.phochak.deprecated.integration;
+//
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import com.nexters.phochak.user.application.JwtTokenService;
+//import com.nexters.phochak.user.application.port.in.JwtTokenUseCase;
+//import com.nexters.phochak.user.domain.OAuthProviderEnum;
+//import org.junit.jupiter.api.BeforeAll;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.TestInstance;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.mock.web.MockMultipartFile;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.test.web.servlet.MockMvc;
+//
+//import java.io.FileInputStream;
+//
+//import static com.nexters.phochak.auth.AuthAspect.AUTHORIZATION_HEADER;
+//import static com.nexters.phochak.common.exception.ResCode.INVALID_INPUT;
+//import static com.nexters.phochak.common.exception.ResCode.OK;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@SpringBootTest
+//@AutoConfigureMockMvc
+//@AutoConfigureRestDocs
+//@ActiveProfiles("test")
+//@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+//@Disabled
+//public class PostLocalStorageIntegrationTest {
+//
+//    @Autowired UserRepository userRepository;
+//    @Autowired
+//    JwtTokenService jwtTokenService;
+//    @Autowired MockMvc mockMvc;
+//
+//    static String testToken;
+//
+//    @BeforeAll
+//    void setUp() {
+//        UserEntity userEntity = UserEntity.builder()
+//                        .providerId("1234")
+//                        .provider(OAuthProviderEnum.KAKAO)
+//                        .nickname("nickname")
+//                        .profileImgUrl(null)
+//                        .build();
+//        userRepository.save(userEntity);
+//        JwtTokenUseCase.TokenVo tokenDto = jwtTokenService.generateToken(userEntity.getId(), 999999999L);
+//        testToken = JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + tokenDto.getTokenString();
+//    }
+//
+//    @Test
+//    @DisplayName("게시글 생성 성공")
+//    void createPost_success() throws Exception {
+//        // given
+//        MockMultipartFile testVideo = new MockMultipartFile(
+//                "shorts",
+//                "test.mov",
+//                "video/mov",
+//                new FileInputStream("app-resource/test/dummy/test.mov"));
+//
+//        // when, then
+//        mockMvc.perform(multipart("/v1/post")
+//                .file(testVideo)
+//                .param("postCategory", "RESTAURANT")
+//                .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
+//                .header(AUTHORIZATION_HEADER, testToken)
+//        ).andExpect(status().isOk())
+//        .andExpect(jsonPath("$.status.resCode").value(OK.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("게시글 작성 필수 파라미터가 없는 경우 INVALID_INPUT 예외가 발생한다")
+//    void createPostValidateEssentialParameter_InvalidInput() throws Exception {
+//        // given
+//        MockMultipartFile testVideo = new MockMultipartFile(
+//                "shorts",
+//                "test.mov",
+//                "video/mov",
+//                new FileInputStream("app-resource/test/dummy/test.mov"));
+//
+//        // when, then
+//        mockMvc.perform(multipart("/v1/post")
+//                        .param("postCategory", "RESTAURANT")
+//                        .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//
+//        mockMvc.perform(multipart("/v1/post")
+//                        .file(testVideo)
+//                        .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//
+//        mockMvc.perform(multipart("/v1/post")
+//                        .file(testVideo)
+//                        .param("postCategory", "RESTAURANT")
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("존재하지 않는 카테고리 입력 시에 INVALID_INPUT 예외가 발생한다")
+//    void createPostValidateCategory_InvalidInput() throws Exception {
+//        // given
+//        MockMultipartFile testVideo = new MockMultipartFile(
+//                "shorts",
+//                "test.mov",
+//                "video/mov",
+//                new FileInputStream("app-resource/test/dummy/test.mov"));
+//
+//        // when, then
+//        mockMvc.perform(multipart("/v1/post")
+//                        .file(testVideo)
+//                        .param("postCategory", "INVALIDCATEGORY")
+//                        .param("hashtags", "[\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("해시태그의 개수가 30개가 넘으면, INVALID_INPUT 예외가 발생한다")
+//    void HashtagOver30_InvalidInput() throws Exception {
+//        // given
+//        MockMultipartFile testVideo = new MockMultipartFile(
+//                "shorts",
+//                "test.mov",
+//                "video/mov",
+//                new FileInputStream("app-resource/test/dummy/test.mov"));
+//
+//        StringBuilder hashtagStringList = new StringBuilder("[");
+//        for(int i=0;i<31;i++) {
+//            hashtagStringList.append("\"해시태그").append(i).append("\",");
+//        }
+//        hashtagStringList.deleteCharAt(hashtagStringList.length() - 1);
+//        hashtagStringList.append("]");
+//
+//        // when, then
+//        mockMvc.perform(multipart("/v1/post")
+//                        .file(testVideo)
+//                        .param("postCategory", "RESTAURANT")
+//                        .param("hashtags", hashtagStringList.toString())
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/integration/PostNcpIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/PostNcpIntegrationTest.java
@@ -1,414 +1,414 @@
-package com.nexters.phochak.deprecated.integration;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nexters.phochak.common.docs.RestDocs;
-import com.nexters.phochak.common.exception.CustomExceptionHandler;
-import com.nexters.phochak.post.adapter.in.web.PostController;
-import com.nexters.phochak.post.adapter.out.api.ReportNotificationFeignClient;
-import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
-import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
-import com.nexters.phochak.post.adapter.out.persistence.ReportPostRepository;
-import com.nexters.phochak.post.domain.PostCategoryEnum;
-import com.nexters.phochak.shorts.adapter.out.api.NCPStorageClient;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsRepository;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import com.nexters.phochak.user.application.JwtTokenService;
-import com.nexters.phochak.user.application.port.in.JwtTokenUseCase;
-import com.nexters.phochak.user.domain.OAuthProviderEnum;
-import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationContextProvider;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static com.nexters.phochak.auth.AuthAspect.AUTHORIZATION_HEADER;
-import static com.nexters.phochak.common.exception.ResCode.INVALID_INPUT;
-import static com.nexters.phochak.common.exception.ResCode.OK;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@Disabled
-@SpringBootTest
-@AutoConfigureMockMvc
-@AutoConfigureRestDocs
-@ActiveProfiles("test")
-@Transactional
-class PostNcpIntegrationTest extends RestDocs {
-
-    @Autowired UserRepository userRepository;
-    @Autowired
-    JwtTokenService jwtTokenService;
-    @Autowired
-    PostController postController;
-    @Autowired EntityManager em;
-    @Autowired ObjectMapper objectMapper;
-    MockMvc mockMvc;
-    static String testToken;
-    @Autowired
-    private PostRepository postRepository;
-    @Autowired
-    private ShortsRepository shortsRepository;
-    @MockBean NCPStorageClient ncpStorageClient;
-    @MockBean
-    ReportNotificationFeignClient slackPostReportFeignClient;
-    @Autowired
-    private HashtagRepository hashtagRepository;
-    @Autowired
-    private ReportPostRepository reportPostRepository;
-
-    @BeforeEach
-    void setUp(RestDocumentationContextProvider restDocumentation) {
-        this.mockMvc = getMockMvcBuilder(restDocumentation, postController)
-                .setControllerAdvice(CustomExceptionHandler.class)
-                .build();
-        UserEntity userEntity = UserEntity.builder()
-                .providerId("1234")
-                .provider(OAuthProviderEnum.KAKAO)
-                .nickname("nickname")
-                .profileImgUrl(null)
-                .build();
-        userRepository.save(userEntity);
-        JwtTokenUseCase.TokenVo tokenDto = jwtTokenService.generateToken(userEntity.getId(), 999999999L);
-        testToken = JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + tokenDto.getTokenString();
-    }
-
-    @Test
-    @DisplayName("포스트 API - upload key 생성 성공")
-    void uploadKey_success() throws Exception {
-        //given
-        given(ncpStorageClient.generatePresignedUrl(any())).willReturn(new URL("http://test.com"));
-
-        // when, then
-        mockMvc.perform(get("/v1/post/upload-key")
-                        .queryParam("file-extension", "mov")
-                        .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                .andDo(document("post/upload-key/GET",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("file-extension").description("파일 생성자 ex) mp4")
-                        ),
-                        requestHeaders(
-                                headerWithName(AUTHORIZATION_HEADER)
-                                        .description("JWT Access Token")
-                        ),
-                        responseFields(
-                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data.uploadUrl").type(JsonFieldType.STRING).description("파일 업로드 URL"),
-                                fieldWithPath("data.uploadKey").type(JsonFieldType.STRING).description("업로드 키")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("포스트 API - 게시글 생성 성공")
-    void createPost_success() throws Exception {
-        //given
-        Map<String, Object> body = new HashMap<>();
-        body.put("uploadKey", "uploadKey");
-        body.put("category", "RESTAURANT");
-        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
-
-        // when, then
-        mockMvc.perform(post("/v1/post")
-            .content(objectMapper.writeValueAsString(body))
-            .contentType(MediaType.APPLICATION_JSON)
-            .header(AUTHORIZATION_HEADER, testToken))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-            .andDo(document("post/POST",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                requestFields(
-                        fieldWithPath("category").description("카테고리 ex) TOUR / RESTAURANT / CAFE"),
-                        fieldWithPath("uploadKey").description("발급 받았던 업로드 키"),
-                        fieldWithPath("hashtags").description("해시태그 배열 ex) [\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
-                ),
-                requestHeaders(
-                        headerWithName(AUTHORIZATION_HEADER)
-                                .description("JWT Access Token")
-                ),
-                responseFields(
-                        fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                        fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                        fieldWithPath("data").type(JsonFieldType.NULL).description("null")
-                )
-        ));
-    }
-
-    @Test
-    @DisplayName("포스트 API - 게시글 수정 성공")
-    void updatePost_success() throws Exception {
-        //given
-        UserEntity userEntity = userRepository.findByNickname("nickname").get();
-
-        ShortsEntity shortsEntity = ShortsEntity.builder()
-                .thumbnailUrl("test")
-                .shortsUrl("test")
-                .uploadKey("test")
-                .build();
-        shortsRepository.save(shortsEntity);
-
-        PostEntity postEntity = PostEntity.builder()
-                .shorts(shortsEntity)
-                .postCategory(PostCategoryEnum.TOUR)
-                .userEntity(userEntity)
-                .build();
-        postRepository.save(postEntity);
-        Long postId = postEntity.getId();
-
-        List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
-        hashtagRepository.saveAll(hashtagEntities);
-
-        em.flush();
-        em.clear();
-
-        Map<String, Object> body = new HashMap<>();
-        body.put("category", "RESTAURANT");
-        body.put("hashtags", List.of("해시태그1", "해시태그2"));
-
-        // when, then
-        mockMvc.perform(put("/v1/post/{postId}", postId)
-                .content(objectMapper.writeValueAsString(body))
-                .contentType(MediaType.APPLICATION_JSON)
-                .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                .andDo(document("post/PUT",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        pathParameters(
-                                parameterWithName("postId").description("(필수) 수정할 포스트의 id")
-                        ),
-                        requestFields(
-                                fieldWithPath("category").description("카테고리 ex) TOUR / RESTAURANT / CAFE"),
-                                fieldWithPath("hashtags").description("해시태그 배열 ex) [\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
-                        ),
-                        requestHeaders(
-                                headerWithName(AUTHORIZATION_HEADER)
-                                        .description("JWT Access Token")
-                        ),
-                        responseFields(
-                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
-                        )
-                ));
-    }
-
-    @Test
-    @DisplayName("포스트 API - 게시글 삭제 성공")
-    void deletePost_success() throws Exception {
-        //given
-        UserEntity userEntity = userRepository.findByNickname("nickname").get();
-
-        ShortsEntity shortsEntity = ShortsEntity.builder()
-                .thumbnailUrl("test")
-                .shortsUrl("test")
-                .uploadKey("test")
-                .build();
-        shortsRepository.save(shortsEntity);
-
-        PostEntity postEntity = PostEntity.builder()
-                        .shorts(shortsEntity)
-                        .postCategory(PostCategoryEnum.TOUR)
-                        .userEntity(userEntity)
-                        .build();
-        postRepository.save(postEntity);
-        Long postId = postEntity.getId();
-
-        List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
-        hashtagRepository.saveAll(hashtagEntities);
-
-        em.flush();
-        em.clear();
-
-        // when, then
-        mockMvc.perform(delete("/v1/post/{postId}", postId)
-                        .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                .andDo(document("post/DELETE",
-                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        pathParameters(
-                                parameterWithName("postId").description("(필수) 삭제할 포스트의 id")
-                        ),
-                        requestHeaders(
-                                headerWithName(AUTHORIZATION_HEADER)
-                                        .description("JWT Access Token")
-                        ),
-                        responseFields(
-                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
-                        )
-                ));
-        Assertions.assertThat(postRepository.count()).isZero();
-        Assertions.assertThat(shortsRepository.count()).isZero();
-    }
-
-    @Test
-    @DisplayName("포스트 API - 게시글 작성 필수 파라미터가 없는 경우 INVALID_INPUT 예외가 발생한다")
-    void createPostValidateEssentialParameter_InvalidInput() throws Exception {
-        //given
-        Map<String, Object> body = new HashMap<>();
-        body.put("category", "RESTAURANT");
-        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
-
-        // when, then
-        mockMvc.perform(post("/v1/post")
-                        .content(objectMapper.writeValueAsString(body))
-                        .characterEncoding("utf-8")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-
-        //given
-        body = new HashMap<>();
-        body.put("uploadKey", "uploadKey");
-        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
-
-        // when, then
-        mockMvc.perform(post("/v1/post")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-
-        //given
-        body = new HashMap<>();
-        body.put("uploadKey", "uploadKey");
-        body.put("category", "RESTAURANT");
-
-        // when, then
-        mockMvc.perform(post("/v1/post")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-    }
-
-    @Test
-    @DisplayName("포스트 API - 존재하지 않는 카테고리 입력 시에 INVALID_INPUT 예외가 발생한다")
-    void createPostValidateCategory_InvalidInput() throws Exception {
-        //given
-        Map<String, Object> body = new HashMap<>();
-        body.put("key", "key");
-        body.put("category", "INVALIDCATEGORY");
-        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
-
-        // when, then
-        mockMvc.perform(post("/v1/post")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-    }
-
-    @Test
-    @DisplayName("포스트 API - 해시태그의 개수가 30개가 넘으면, INVALID_INPUT 예외가 발생한다")
-    void HashtagOver30_InvalidInput() throws Exception {
-        //given
-        List<String> hashtagList = new ArrayList<>();
-        for(int i=0;i<31;i++) {
-            hashtagList.add("해시태그"+i);
-        }
-
-        Map<String, Object> body = new HashMap<>();
-        body.put("key", "key");
-        body.put("category", "RESTAURANT");
-        body.put("hashtags", hashtagList);
-
-        // when, then
-        mockMvc.perform(post("/v1/post")
-                        .content(objectMapper.writeValueAsString(body))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER, testToken)
-                ).andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
-    }
-
-    @Test
-    @DisplayName("포스트 API - 게시글 신고하기 성공")
-    void reportPost() throws Exception {
-        UserEntity userEntity = userRepository.findByNickname("nickname").get();
-
-        ShortsEntity shortsEntity = ShortsEntity.builder()
-                .thumbnailUrl("test")
-                .shortsUrl("test")
-                .uploadKey("test")
-                .build();
-        shortsRepository.save(shortsEntity);
-
-        PostEntity postEntity = PostEntity.builder()
-                .shorts(shortsEntity)
-                .postCategory(PostCategoryEnum.TOUR)
-                .userEntity(userEntity)
-                .build();
-        postRepository.save(postEntity);
-        Long postId = postEntity.getId();
-
-        // when, then
-        mockMvc.perform(post("/v1/post/{postId}/report", postId)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .header(AUTHORIZATION_HEADER, testToken))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
-                .andDo(document("post/report",
-                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
-                        preprocessResponse(prettyPrint()),
-                        pathParameters(
-                                parameterWithName("postId").description("(필수) 신고할 포스트의 id")
-                        ),
-                        requestHeaders(
-                                headerWithName(AUTHORIZATION_HEADER)
-                                        .description("JWT Access Token")
-                        ),
-                        responseFields(
-                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
-                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
-                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
-                        )
-                ));
-    }
-}
+//package com.nexters.phochak.deprecated.integration;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.nexters.phochak.common.docs.RestDocs;
+//import com.nexters.phochak.common.exception.CustomExceptionHandler;
+//import com.nexters.phochak.post.adapter.in.web.PostController;
+//import com.nexters.phochak.post.adapter.out.api.ReportNotificationFeignClient;
+//import com.nexters.phochak.post.adapter.out.persistence.HashtagEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.HashtagRepository;
+//import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
+//import com.nexters.phochak.post.adapter.out.persistence.ReportPostRepository;
+//import com.nexters.phochak.post.domain.PostCategoryEnum;
+//import com.nexters.phochak.shorts.adapter.out.api.NCPStorageClient;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsRepository;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import com.nexters.phochak.user.application.JwtTokenService;
+//import com.nexters.phochak.user.application.port.in.JwtTokenUseCase;
+//import com.nexters.phochak.user.domain.OAuthProviderEnum;
+//import jakarta.persistence.EntityManager;
+//import org.assertj.core.api.Assertions;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.http.MediaType;
+//import org.springframework.restdocs.RestDocumentationContextProvider;
+//import org.springframework.restdocs.payload.JsonFieldType;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.net.URL;
+//import java.util.ArrayList;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//
+//import static com.nexters.phochak.auth.AuthAspect.AUTHORIZATION_HEADER;
+//import static com.nexters.phochak.common.exception.ResCode.INVALID_INPUT;
+//import static com.nexters.phochak.common.exception.ResCode.OK;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.BDDMockito.given;
+//import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+//import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+//import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+//import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+//import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+//import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@Disabled
+//@SpringBootTest
+//@AutoConfigureMockMvc
+//@AutoConfigureRestDocs
+//@ActiveProfiles("test")
+//@Transactional
+//class PostNcpIntegrationTest extends RestDocs {
+//
+//    @Autowired UserRepository userRepository;
+//    @Autowired
+//    JwtTokenService jwtTokenService;
+//    @Autowired
+//    PostController postController;
+//    @Autowired EntityManager em;
+//    @Autowired ObjectMapper objectMapper;
+//    MockMvc mockMvc;
+//    static String testToken;
+//    @Autowired
+//    private PostRepository postRepository;
+//    @Autowired
+//    private ShortsRepository shortsRepository;
+//    @MockBean NCPStorageClient ncpStorageClient;
+//    @MockBean
+//    ReportNotificationFeignClient slackPostReportFeignClient;
+//    @Autowired
+//    private HashtagRepository hashtagRepository;
+//    @Autowired
+//    private ReportPostRepository reportPostRepository;
+//
+//    @BeforeEach
+//    void setUp(RestDocumentationContextProvider restDocumentation) {
+//        this.mockMvc = getMockMvcBuilder(restDocumentation, postController)
+//                .setControllerAdvice(CustomExceptionHandler.class)
+//                .build();
+//        UserEntity userEntity = UserEntity.builder()
+//                .providerId("1234")
+//                .provider(OAuthProviderEnum.KAKAO)
+//                .nickname("nickname")
+//                .profileImgUrl(null)
+//                .build();
+//        userRepository.save(userEntity);
+//        JwtTokenUseCase.TokenVo tokenDto = jwtTokenService.generateToken(userEntity.getId(), 999999999L);
+//        testToken = JwtTokenUseCase.TokenVo.TOKEN_TYPE + " " + tokenDto.getTokenString();
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - upload key 생성 성공")
+//    void uploadKey_success() throws Exception {
+//        //given
+//        given(ncpStorageClient.generatePresignedUrl(any())).willReturn(new URL("http://test.com"));
+//
+//        // when, then
+//        mockMvc.perform(get("/v1/post/upload-key")
+//                        .queryParam("file-extension", "mov")
+//                        .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                .andDo(document("post/upload-key/GET",
+//                        preprocessRequest(prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        requestFields(
+//                                fieldWithPath("file-extension").description("파일 생성자 ex) mp4")
+//                        ),
+//                        requestHeaders(
+//                                headerWithName(AUTHORIZATION_HEADER)
+//                                        .description("JWT Access Token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                                fieldWithPath("data.uploadUrl").type(JsonFieldType.STRING).description("파일 업로드 URL"),
+//                                fieldWithPath("data.uploadKey").type(JsonFieldType.STRING).description("업로드 키")
+//                        )
+//                ));
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 게시글 생성 성공")
+//    void createPost_success() throws Exception {
+//        //given
+//        Map<String, Object> body = new HashMap<>();
+//        body.put("uploadKey", "uploadKey");
+//        body.put("category", "RESTAURANT");
+//        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post")
+//            .content(objectMapper.writeValueAsString(body))
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .header(AUTHORIZATION_HEADER, testToken))
+//            .andExpect(status().isOk())
+//            .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//            .andDo(document("post/POST",
+//                preprocessRequest(prettyPrint()),
+//                preprocessResponse(prettyPrint()),
+//                requestFields(
+//                        fieldWithPath("category").description("카테고리 ex) TOUR / RESTAURANT / CAFE"),
+//                        fieldWithPath("uploadKey").description("발급 받았던 업로드 키"),
+//                        fieldWithPath("hashtags").description("해시태그 배열 ex) [\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
+//                ),
+//                requestHeaders(
+//                        headerWithName(AUTHORIZATION_HEADER)
+//                                .description("JWT Access Token")
+//                ),
+//                responseFields(
+//                        fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                        fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                        fieldWithPath("data").type(JsonFieldType.NULL).description("null")
+//                )
+//        ));
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 게시글 수정 성공")
+//    void updatePost_success() throws Exception {
+//        //given
+//        UserEntity userEntity = userRepository.findByNickname("nickname").get();
+//
+//        ShortsEntity shortsEntity = ShortsEntity.builder()
+//                .thumbnailUrl("test")
+//                .shortsUrl("test")
+//                .uploadKey("test")
+//                .build();
+//        shortsRepository.save(shortsEntity);
+//
+//        PostEntity postEntity = PostEntity.builder()
+//                .shorts(shortsEntity)
+//                .postCategory(PostCategoryEnum.TOUR)
+//                .userEntity(userEntity)
+//                .build();
+//        postRepository.save(postEntity);
+//        Long postId = postEntity.getId();
+//
+//        List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
+//        hashtagRepository.saveAll(hashtagEntities);
+//
+//        em.flush();
+//        em.clear();
+//
+//        Map<String, Object> body = new HashMap<>();
+//        body.put("category", "RESTAURANT");
+//        body.put("hashtags", List.of("해시태그1", "해시태그2"));
+//
+//        // when, then
+//        mockMvc.perform(put("/v1/post/{postId}", postId)
+//                .content(objectMapper.writeValueAsString(body))
+//                .contentType(MediaType.APPLICATION_JSON)
+//                .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                .andDo(document("post/PUT",
+//                        preprocessRequest(prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        pathParameters(
+//                                parameterWithName("postId").description("(필수) 수정할 포스트의 id")
+//                        ),
+//                        requestFields(
+//                                fieldWithPath("category").description("카테고리 ex) TOUR / RESTAURANT / CAFE"),
+//                                fieldWithPath("hashtags").description("해시태그 배열 ex) [\"해시태그1\", \"해시태그2\", \"해시태그3\"))]")
+//                        ),
+//                        requestHeaders(
+//                                headerWithName(AUTHORIZATION_HEADER)
+//                                        .description("JWT Access Token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
+//                        )
+//                ));
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 게시글 삭제 성공")
+//    void deletePost_success() throws Exception {
+//        //given
+//        UserEntity userEntity = userRepository.findByNickname("nickname").get();
+//
+//        ShortsEntity shortsEntity = ShortsEntity.builder()
+//                .thumbnailUrl("test")
+//                .shortsUrl("test")
+//                .uploadKey("test")
+//                .build();
+//        shortsRepository.save(shortsEntity);
+//
+//        PostEntity postEntity = PostEntity.builder()
+//                        .shorts(shortsEntity)
+//                        .postCategory(PostCategoryEnum.TOUR)
+//                        .userEntity(userEntity)
+//                        .build();
+//        postRepository.save(postEntity);
+//        Long postId = postEntity.getId();
+//
+//        List<HashtagEntity> hashtagEntities = List.of(new HashtagEntity(postEntity, "hashtag1"), new HashtagEntity(postEntity, "hashtag2"), new HashtagEntity(postEntity, "hashtag3"));
+//        hashtagRepository.saveAll(hashtagEntities);
+//
+//        em.flush();
+//        em.clear();
+//
+//        // when, then
+//        mockMvc.perform(delete("/v1/post/{postId}", postId)
+//                        .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                .andDo(document("post/DELETE",
+//                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        pathParameters(
+//                                parameterWithName("postId").description("(필수) 삭제할 포스트의 id")
+//                        ),
+//                        requestHeaders(
+//                                headerWithName(AUTHORIZATION_HEADER)
+//                                        .description("JWT Access Token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
+//                        )
+//                ));
+//        Assertions.assertThat(postRepository.count()).isZero();
+//        Assertions.assertThat(shortsRepository.count()).isZero();
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 게시글 작성 필수 파라미터가 없는 경우 INVALID_INPUT 예외가 발생한다")
+//    void createPostValidateEssentialParameter_InvalidInput() throws Exception {
+//        //given
+//        Map<String, Object> body = new HashMap<>();
+//        body.put("category", "RESTAURANT");
+//        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .characterEncoding("utf-8")
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//
+//        //given
+//        body = new HashMap<>();
+//        body.put("uploadKey", "uploadKey");
+//        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//
+//        //given
+//        body = new HashMap<>();
+//        body.put("uploadKey", "uploadKey");
+//        body.put("category", "RESTAURANT");
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 존재하지 않는 카테고리 입력 시에 INVALID_INPUT 예외가 발생한다")
+//    void createPostValidateCategory_InvalidInput() throws Exception {
+//        //given
+//        Map<String, Object> body = new HashMap<>();
+//        body.put("key", "key");
+//        body.put("category", "INVALIDCATEGORY");
+//        body.put("hashtags", List.of("해시태그1", "해시태그2", "해시태그3"));
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 해시태그의 개수가 30개가 넘으면, INVALID_INPUT 예외가 발생한다")
+//    void HashtagOver30_InvalidInput() throws Exception {
+//        //given
+//        List<String> hashtagList = new ArrayList<>();
+//        for(int i=0;i<31;i++) {
+//            hashtagList.add("해시태그"+i);
+//        }
+//
+//        Map<String, Object> body = new HashMap<>();
+//        body.put("key", "key");
+//        body.put("category", "RESTAURANT");
+//        body.put("hashtags", hashtagList);
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post")
+//                        .content(objectMapper.writeValueAsString(body))
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .header(AUTHORIZATION_HEADER, testToken)
+//                ).andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(INVALID_INPUT.getCode()));
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 API - 게시글 신고하기 성공")
+//    void reportPost() throws Exception {
+//        UserEntity userEntity = userRepository.findByNickname("nickname").get();
+//
+//        ShortsEntity shortsEntity = ShortsEntity.builder()
+//                .thumbnailUrl("test")
+//                .shortsUrl("test")
+//                .uploadKey("test")
+//                .build();
+//        shortsRepository.save(shortsEntity);
+//
+//        PostEntity postEntity = PostEntity.builder()
+//                .shorts(shortsEntity)
+//                .postCategory(PostCategoryEnum.TOUR)
+//                .userEntity(userEntity)
+//                .build();
+//        postRepository.save(postEntity);
+//        Long postId = postEntity.getId();
+//
+//        // when, then
+//        mockMvc.perform(post("/v1/post/{postId}/report", postId)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .header(AUTHORIZATION_HEADER, testToken))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.status.resCode").value(OK.getCode()))
+//                .andDo(document("post/report",
+//                        preprocessRequest(modifyUris().scheme("http").host("101.101.209.228").removePort(), prettyPrint()),
+//                        preprocessResponse(prettyPrint()),
+//                        pathParameters(
+//                                parameterWithName("postId").description("(필수) 신고할 포스트의 id")
+//                        ),
+//                        requestHeaders(
+//                                headerWithName(AUTHORIZATION_HEADER)
+//                                        .description("JWT Access Token")
+//                        ),
+//                        responseFields(
+//                                fieldWithPath("status.resCode").type(JsonFieldType.STRING).description("응답 코드"),
+//                                fieldWithPath("status.resMessage").type(JsonFieldType.STRING).description("응답 메시지"),
+//                                fieldWithPath("data").type(JsonFieldType.NULL).description("null")
+//                        )
+//                ));
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/integration/ReportPostUseCaseIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/ReportPostUseCaseIntegrationTest.java
@@ -1,122 +1,122 @@
-package com.nexters.phochak.deprecated.integration;
-
-import com.nexters.phochak.common.exception.PhochakException;
-import com.nexters.phochak.post.adapter.out.api.ReportNotificationFeignClient;
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
-import com.nexters.phochak.post.adapter.out.persistence.ReportPostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.ReportPostRepository;
-import com.nexters.phochak.post.application.port.in.ReportPostUseCase;
-import com.nexters.phochak.post.domain.PostCategoryEnum;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
-import com.nexters.phochak.shorts.domain.ShortsStateEnum;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import com.nexters.phochak.user.domain.OAuthProviderEnum;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-@Disabled
-@Transactional
-@ActiveProfiles("test")
-@SpringBootTest
-class ReportPostUseCaseIntegrationTest {
-
-    @Autowired
-    ReportPostUseCase reportPostUseCase;
-    @Autowired
-    UserRepository userRepository;
-    @Autowired
-    PostRepository postRepository;
-    @Autowired
-    ReportPostRepository reportPostRepository;
-    @MockBean
-    ReportNotificationFeignClient slackPostReportFeignClient;
-
-
-    UserEntity userEntity;
-    PostEntity postEntity;
-
-    @BeforeEach
-    void setUp() {
-        userEntity = UserEntity.builder()
-                .id(1234L)
-                .provider(OAuthProviderEnum.KAKAO)
-                .providerId("testId")
-                .nickname("report")
-                .profileImgUrl("testImage")
-                .build();
-        ShortsEntity shortsEntity = new ShortsEntity(1L, ShortsStateEnum.OK, "upload key", "shorts", "thumbnail");
-        postEntity = new PostEntity(userEntity, shortsEntity, PostCategoryEnum.CAFE);
-
-        userRepository.save(userEntity);
-        postRepository.save(postEntity);
-    }
-
-    @Test
-    @DisplayName("신고에 성공하면 신고 카운트가 1 올라간다")
-    void processReport() {
-        // given
-        Long userId = userEntity.getId();
-        Long postId = postEntity.getId();
-
-        // when
-        reportPostUseCase.processReport(userId, postId);
-
-        // then
-        assertThat(reportPostRepository.countByPostId(postEntity.getId())).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("신고 시 중복된 신고가 존재하면 예외가 발생하여 저장에 실패한다")
-    void processReport_fail() {
-        // given
-        Long userId = userEntity.getId();
-        Long postId = postEntity.getId();
-        reportPostUseCase.processReport(userId, postId);
-
-        // when & then
-        assertThat(reportPostRepository.countByPostId(postEntity.getId())).isEqualTo(1);
-        assertThatThrownBy(() -> reportPostUseCase.processReport(userId, postId))
-                .isInstanceOf(PhochakException.class);
-    }
-
-    @Test
-    @DisplayName("신고 카운트가 20개 이상 쌓이면 포스트가 노출되지 않는다")
-    void processReport_overCriteria() throws InterruptedException {
-        // given
-        Long userId = userEntity.getId();
-        Long postId = postEntity.getId();
-        for (int i = 0; i < 19; i++) {
-            UserEntity reporter = userRepository.save(UserEntity.builder()
-                    .nickname("nickname" + i)
-                    .providerId("providerId" + i)
-                    .provider(OAuthProviderEnum.KAKAO)
-                    .build());
-            reportPostRepository.save(ReportPostEntity.builder()
-                    .post(postEntity)
-                    .reporter(reporter)
-                    .build());
-        }
-
-        // when
-        reportPostUseCase.processReport(userId, postId);
-
-        // then
-        Optional<PostEntity> post = postRepository.findById(postId);
-        assertThat(post).isPresent();
-        assertThat(post.get().isBlind()).isTrue();
-    }
-}
+//package com.nexters.phochak.deprecated.integration;
+//
+//import com.nexters.phochak.common.exception.PhochakException;
+//import com.nexters.phochak.post.adapter.out.api.ReportNotificationFeignClient;
+//import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
+//import com.nexters.phochak.post.adapter.out.persistence.ReportPostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.ReportPostRepository;
+//import com.nexters.phochak.post.application.port.in.ReportPostUseCase;
+//import com.nexters.phochak.post.domain.PostCategoryEnum;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
+//import com.nexters.phochak.shorts.domain.ShortsStateEnum;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import com.nexters.phochak.user.domain.OAuthProviderEnum;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
+//
+//@Disabled
+//@Transactional
+//@ActiveProfiles("test")
+//@SpringBootTest
+//class ReportPostUseCaseIntegrationTest {
+//
+//    @Autowired
+//    ReportPostUseCase reportPostUseCase;
+//    @Autowired
+//    UserRepository userRepository;
+//    @Autowired
+//    PostRepository postRepository;
+//    @Autowired
+//    ReportPostRepository reportPostRepository;
+//    @MockBean
+//    ReportNotificationFeignClient slackPostReportFeignClient;
+//
+//
+//    UserEntity userEntity;
+//    PostEntity postEntity;
+//
+//    @BeforeEach
+//    void setUp() {
+//        userEntity = UserEntity.builder()
+//                .id(1234L)
+//                .provider(OAuthProviderEnum.KAKAO)
+//                .providerId("testId")
+//                .nickname("report")
+//                .profileImgUrl("testImage")
+//                .build();
+//        ShortsEntity shortsEntity = new ShortsEntity(1L, ShortsStateEnum.OK, "upload key", "shorts", "thumbnail");
+//        postEntity = new PostEntity(userEntity, shortsEntity, PostCategoryEnum.CAFE);
+//
+//        userRepository.save(userEntity);
+//        postRepository.save(postEntity);
+//    }
+//
+//    @Test
+//    @DisplayName("신고에 성공하면 신고 카운트가 1 올라간다")
+//    void processReport() {
+//        // given
+//        Long userId = userEntity.getId();
+//        Long postId = postEntity.getId();
+//
+//        // when
+//        reportPostUseCase.processReport(userId, postId);
+//
+//        // then
+//        assertThat(reportPostRepository.countByPostId(postEntity.getId())).isEqualTo(1);
+//    }
+//
+//    @Test
+//    @DisplayName("신고 시 중복된 신고가 존재하면 예외가 발생하여 저장에 실패한다")
+//    void processReport_fail() {
+//        // given
+//        Long userId = userEntity.getId();
+//        Long postId = postEntity.getId();
+//        reportPostUseCase.processReport(userId, postId);
+//
+//        // when & then
+//        assertThat(reportPostRepository.countByPostId(postEntity.getId())).isEqualTo(1);
+//        assertThatThrownBy(() -> reportPostUseCase.processReport(userId, postId))
+//                .isInstanceOf(PhochakException.class);
+//    }
+//
+//    @Test
+//    @DisplayName("신고 카운트가 20개 이상 쌓이면 포스트가 노출되지 않는다")
+//    void processReport_overCriteria() throws InterruptedException {
+//        // given
+//        Long userId = userEntity.getId();
+//        Long postId = postEntity.getId();
+//        for (int i = 0; i < 19; i++) {
+//            UserEntity reporter = userRepository.save(UserEntity.builder()
+//                    .nickname("nickname" + i)
+//                    .providerId("providerId" + i)
+//                    .provider(OAuthProviderEnum.KAKAO)
+//                    .build());
+//            reportPostRepository.save(ReportPostEntity.builder()
+//                    .post(postEntity)
+//                    .reporter(reporter)
+//                    .build());
+//        }
+//
+//        // when
+//        reportPostUseCase.processReport(userId, postId);
+//
+//        // then
+//        Optional<PostEntity> post = postRepository.findById(postId);
+//        assertThat(post).isPresent();
+//        assertThat(post.get().isBlind()).isTrue();
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/integration/UserIntegrationTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/integration/UserIntegrationTest.java
@@ -1,85 +1,85 @@
-package com.nexters.phochak.deprecated.integration;
-
-import com.nexters.phochak.post.application.port.in.PostUseCase;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import com.nexters.phochak.user.application.port.in.UserUseCase;
-import com.nexters.phochak.user.domain.OAuthProviderEnum;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@Disabled
-@Transactional
-@AutoConfigureMockMvc
-@ActiveProfiles(profiles = "test")
-@SpringBootTest
-class UserIntegrationTest {
-
-    @Autowired
-    UserUseCase userService;
-    @Autowired
-    MockMvc mockMvc;
-    @Autowired
-    UserRepository userRepository;
-    @MockBean
-    PostUseCase postUseCase;
-
-    UserEntity userEntity;
-
-    @BeforeEach
-    void setUp() {
-        String nickname = "testUser";
-
-        userEntity = UserEntity.builder()
-                .nickname(nickname)
-                .provider(OAuthProviderEnum.KAKAO)
-                .providerId("test")
-                .build();
-    }
-
-    @Test
-    @DisplayName("중복된 닉네임으로 가입하면 isDuplicated가 true로 반환된다")
-    void duplicatedTest() throws Exception {
-        // given
-        String nickname = "testUser";
-
-        userRepository.save(userEntity);
-
-        // when & then
-        mockMvc.perform(get("/v1/user/check/nickname")
-                .param("nickname", nickname))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.isDuplicated").value(true));
-    }
-
-    @Test
-    @DisplayName("회원 탈퇴 시 탈퇴 일시가 기록된다")
-    void withdrawTest() {
-        // given
-        userRepository.save(userEntity);
-
-        // when
-        userService.withdraw(userEntity.getId());
-
-        // then
-        Optional<UserEntity> findUser = userRepository.findById(userEntity.getId());
-        assertThat(findUser).isPresent();
-        assertThat(findUser.get().getLeaveDate()).isNotNull();
-    }
-}
+//package com.nexters.phochak.deprecated.integration;
+//
+//import com.nexters.phochak.post.application.port.in.PostUseCase;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import com.nexters.phochak.user.application.port.in.UserUseCase;
+//import com.nexters.phochak.user.domain.OAuthProviderEnum;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@Disabled
+//@Transactional
+//@AutoConfigureMockMvc
+//@ActiveProfiles(profiles = "test")
+//@SpringBootTest
+//class UserIntegrationTest {
+//
+//    @Autowired
+//    UserUseCase userService;
+//    @Autowired
+//    MockMvc mockMvc;
+//    @Autowired
+//    UserRepository userRepository;
+//    @MockBean
+//    PostUseCase postUseCase;
+//
+//    UserEntity userEntity;
+//
+//    @BeforeEach
+//    void setUp() {
+//        String nickname = "testUser";
+//
+//        userEntity = UserEntity.builder()
+//                .nickname(nickname)
+//                .provider(OAuthProviderEnum.KAKAO)
+//                .providerId("test")
+//                .build();
+//    }
+//
+//    @Test
+//    @DisplayName("중복된 닉네임으로 가입하면 isDuplicated가 true로 반환된다")
+//    void duplicatedTest() throws Exception {
+//        // given
+//        String nickname = "testUser";
+//
+//        userRepository.save(userEntity);
+//
+//        // when & then
+//        mockMvc.perform(get("/v1/user/check/nickname")
+//                .param("nickname", nickname))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.data.isDuplicated").value(true));
+//    }
+//
+//    @Test
+//    @DisplayName("회원 탈퇴 시 탈퇴 일시가 기록된다")
+//    void withdrawTest() {
+//        // given
+//        userRepository.save(userEntity);
+//
+//        // when
+//        userService.withdraw(userEntity.getId());
+//
+//        // then
+//        Optional<UserEntity> findUser = userRepository.findById(userEntity.getId());
+//        assertThat(findUser).isPresent();
+//        assertThat(findUser.get().getLeaveDate()).isNotNull();
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/repository/FcmDeviceTokenRepositoryTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/repository/FcmDeviceTokenRepositoryTest.java
@@ -1,87 +1,87 @@
-package com.nexters.phochak.deprecated.repository;
-
-import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
-import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenRepository;
-import com.nexters.phochak.notification.domain.OperatingSystem;
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
-import com.nexters.phochak.post.domain.PostCategoryEnum;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
-import com.nexters.phochak.shorts.adapter.out.persistence.ShortsRepository;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import com.nexters.phochak.user.domain.OAuthProviderEnum;
-import jakarta.persistence.EntityManager;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-@Disabled
-@SpringBootTest
-@ActiveProfiles("test")
-@Transactional
-class FcmDeviceTokenRepositoryTest {
-
-    @Autowired
-    private FcmDeviceTokenRepository fcmDeviceTokenRepository;
-    @Autowired
-    private UserRepository userRepository;
-    @Autowired
-    private PostRepository postRepository;
-    @Autowired
-    private ShortsRepository shortsRepository;
-    @Autowired
-    private EntityManager em;
-
-    @DisplayName("uploadKey로 device 조회 쿼리가 정상적으로 조회된다.")
-    @Test
-    void findDeviceTokenAndPostIdByUploadKey() {
-        UserEntity userEntity = UserEntity.builder()
-                .nickname("nickname")
-                .profileImgUrl("url")
-                .provider(OAuthProviderEnum.KAKAO)
-                .providerId("id")
-                .isBlocked(false)
-                .build();
-        userRepository.save(userEntity);
-
-        ShortsEntity shortsEntity = ShortsEntity.builder()
-                .uploadKey("uploadKey")
-                .shortsUrl("url")
-                .thumbnailUrl("url")
-                .build();
-        shortsRepository.save(shortsEntity);
-
-        PostEntity postEntity = PostEntity.builder()
-                .shorts(shortsEntity)
-                .postCategory(PostCategoryEnum.TOUR)
-                .userEntity(userEntity)
-                .build();
-        postRepository.save(postEntity);
-        Long postId = postEntity.getId();
-
-        FcmDeviceTokenEntity fcmDeviceTokenEntity = FcmDeviceTokenEntity.builder()
-                .token("deviceToken")
-                .operatingSystem(OperatingSystem.ANDROID)
-                .user(userEntity)
-                .build();
-        fcmDeviceTokenRepository.save(fcmDeviceTokenEntity);
-        em.flush();
-        em.clear();
-
-        List<Object[]> resultList = fcmDeviceTokenRepository.findDeviceTokenAndPostIdByUploadKey("uploadKey");
-
-        String resultDeviceToken = resultList.get(0)[0].toString();
-        Long resultPostId = Long.valueOf(String.valueOf(resultList.get(0)[1]));
-
-        Assertions.assertThat(resultDeviceToken).isEqualTo("deviceToken");
-        Assertions.assertThat(resultPostId).isEqualTo(postId);
-    }
-}
+//package com.nexters.phochak.deprecated.repository;
+//
+//import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
+//import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenRepository;
+//import com.nexters.phochak.notification.domain.OperatingSystem;
+//import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
+//import com.nexters.phochak.post.domain.PostCategoryEnum;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsEntity;
+//import com.nexters.phochak.shorts.adapter.out.persistence.ShortsRepository;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import com.nexters.phochak.user.domain.OAuthProviderEnum;
+//import jakarta.persistence.EntityManager;
+//import org.assertj.core.api.Assertions;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.test.context.ActiveProfiles;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import java.util.List;
+//
+//@Disabled
+//@SpringBootTest
+//@ActiveProfiles("test")
+//@Transactional
+//class FcmDeviceTokenRepositoryTest {
+//
+//    @Autowired
+//    private FcmDeviceTokenRepository fcmDeviceTokenRepository;
+//    @Autowired
+//    private UserRepository userRepository;
+//    @Autowired
+//    private PostRepository postRepository;
+//    @Autowired
+//    private ShortsRepository shortsRepository;
+//    @Autowired
+//    private EntityManager em;
+//
+//    @DisplayName("uploadKey로 device 조회 쿼리가 정상적으로 조회된다.")
+//    @Test
+//    void findDeviceTokenAndPostIdByUploadKey() {
+//        UserEntity userEntity = UserEntity.builder()
+//                .nickname("nickname")
+//                .profileImgUrl("url")
+//                .provider(OAuthProviderEnum.KAKAO)
+//                .providerId("id")
+//                .isBlocked(false)
+//                .build();
+//        userRepository.save(userEntity);
+//
+//        ShortsEntity shortsEntity = ShortsEntity.builder()
+//                .uploadKey("uploadKey")
+//                .shortsUrl("url")
+//                .thumbnailUrl("url")
+//                .build();
+//        shortsRepository.save(shortsEntity);
+//
+//        PostEntity postEntity = PostEntity.builder()
+//                .shorts(shortsEntity)
+//                .postCategory(PostCategoryEnum.TOUR)
+//                .userEntity(userEntity)
+//                .build();
+//        postRepository.save(postEntity);
+//        Long postId = postEntity.getId();
+//
+//        FcmDeviceTokenEntity fcmDeviceTokenEntity = FcmDeviceTokenEntity.builder()
+//                .token("deviceToken")
+//                .operatingSystem(OperatingSystem.ANDROID)
+//                .user(userEntity)
+//                .build();
+//        fcmDeviceTokenRepository.save(fcmDeviceTokenEntity);
+//        em.flush();
+//        em.clear();
+//
+//        List<Object[]> resultList = fcmDeviceTokenRepository.findDeviceTokenAndPostIdByUploadKey("uploadKey");
+//
+//        String resultDeviceToken = resultList.get(0)[0].toString();
+//        Long resultPostId = Long.valueOf(String.valueOf(resultList.get(0)[1]));
+//
+//        Assertions.assertThat(resultDeviceToken).isEqualTo("deviceToken");
+//        Assertions.assertThat(resultPostId).isEqualTo(postId);
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/service/LikesUseCaseTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/service/LikesUseCaseTest.java
@@ -1,109 +1,109 @@
-package com.nexters.phochak.deprecated.service;
-
-import com.nexters.phochak.common.exception.PhochakException;
-import com.nexters.phochak.post.adapter.out.persistence.LikesEntity;
-import com.nexters.phochak.post.adapter.out.persistence.LikesRepository;
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
-import com.nexters.phochak.post.application.LikeService;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.dao.DataIntegrityViolationException;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
-
-@Disabled
-@ExtendWith(MockitoExtension.class)
-class LikesUseCaseTest {
-
-    @InjectMocks
-    LikeService likeService;
-
-    @Mock UserRepository userRepository;
-    @Mock PostRepository postRepository;
-    @Mock
-    LikesRepository likesRepository;
-
-    @Test
-    @DisplayName("포착하기 성공")
-    void addPhochak() {
-        //given
-        UserEntity userEntity = new UserEntity();
-        PostEntity postEntity = new PostEntity();
-        LikesEntity likesEntity = new LikesEntity(userEntity, postEntity);
-
-        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
-        given(postRepository.findById(anyLong())).willReturn(Optional.of(postEntity));
-        given(likesRepository.save(refEq(likesEntity))).willReturn(likesEntity);
-
-        //then
-        likeService.addPhochak(0L, 0L);
-
-        //then
-        verify(likesRepository, times(1)).save(any());
-    }
-
-    @Test
-    @DisplayName("이미 포착된 게시글은 ALREADY_PHOCHAKED 예외가 발생한다")
-    void addPhochak_alreadyPhochaked() {
-        //given
-        UserEntity userEntity = new UserEntity();
-        PostEntity postEntity = new PostEntity();
-
-        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
-        given(postRepository.findById(anyLong())).willReturn(Optional.of(postEntity));
-        given(likesRepository.save(refEq(new LikesEntity(userEntity, postEntity)))).willThrow(DataIntegrityViolationException.class);
-
-        //when, then
-        assertThatThrownBy(() -> likeService.addPhochak(0L, 0L))
-                .isInstanceOf(PhochakException.class);
-    }
-
-    @Test
-    @DisplayName("포착 취소하기 성공")
-    void cancelPhochak() {
-        //given
-        UserEntity userEntity = new UserEntity();
-        PostEntity postEntity = new PostEntity();
-        LikesEntity likesEntity = new LikesEntity();
-
-        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
-        given(postRepository.getReferenceById(anyLong())).willReturn(postEntity);
-        given(likesRepository.findByUserAndPost(userEntity, postEntity)).willReturn(Optional.of(likesEntity));
-
-        //then
-        likeService.cancelPhochak(0L, 0L);
-
-        //then
-        verify(likesRepository, times(1)).delete(any());
-    }
-
-    @Test
-    @DisplayName("포착되지 않았던 게시글을 포착 취소하면 NOT_PHOCHAKED 예외가 발생한다")
-    void cancelPhochak_notPhochaked() {
-        //given
-        UserEntity userEntity = new UserEntity();
-        PostEntity postEntity = new PostEntity();
-
-        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
-        given(postRepository.getReferenceById(anyLong())).willReturn(postEntity);
-        given(likesRepository.findByUserAndPost(userEntity, postEntity)).willReturn(Optional.empty());
-
-        //when, then
-        assertThatExceptionOfType(PhochakException.class).isThrownBy(() -> likeService.cancelPhochak(0L, 0L));
-        verify(likesRepository, never()).delete(any());
-    }
-}
+//package com.nexters.phochak.deprecated.service;
+//
+//import com.nexters.phochak.common.exception.PhochakException;
+//import com.nexters.phochak.post.adapter.out.persistence.LikesEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.LikesRepository;
+//import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
+//import com.nexters.phochak.post.application.LikeService;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//import org.springframework.dao.DataIntegrityViolationException;
+//
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
+//import static org.mockito.ArgumentMatchers.*;
+//import static org.mockito.BDDMockito.given;
+//import static org.mockito.Mockito.*;
+//
+//@Disabled
+//@ExtendWith(MockitoExtension.class)
+//class LikesUseCaseTest {
+//
+//    @InjectMocks
+//    LikeService likeService;
+//
+//    @Mock UserRepository userRepository;
+//    @Mock PostRepository postRepository;
+//    @Mock
+//    LikesRepository likesRepository;
+//
+//    @Test
+//    @DisplayName("포착하기 성공")
+//    void addPhochak() {
+//        //given
+//        UserEntity userEntity = new UserEntity();
+//        PostEntity postEntity = new PostEntity();
+//        LikesEntity likesEntity = new LikesEntity(userEntity, postEntity);
+//
+//        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
+//        given(postRepository.findById(anyLong())).willReturn(Optional.of(postEntity));
+//        given(likesRepository.save(refEq(likesEntity))).willReturn(likesEntity);
+//
+//        //then
+//        likeService.addPhochak(0L, 0L);
+//
+//        //then
+//        verify(likesRepository, times(1)).save(any());
+//    }
+//
+//    @Test
+//    @DisplayName("이미 포착된 게시글은 ALREADY_PHOCHAKED 예외가 발생한다")
+//    void addPhochak_alreadyPhochaked() {
+//        //given
+//        UserEntity userEntity = new UserEntity();
+//        PostEntity postEntity = new PostEntity();
+//
+//        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
+//        given(postRepository.findById(anyLong())).willReturn(Optional.of(postEntity));
+//        given(likesRepository.save(refEq(new LikesEntity(userEntity, postEntity)))).willThrow(DataIntegrityViolationException.class);
+//
+//        //when, then
+//        assertThatThrownBy(() -> likeService.addPhochak(0L, 0L))
+//                .isInstanceOf(PhochakException.class);
+//    }
+//
+//    @Test
+//    @DisplayName("포착 취소하기 성공")
+//    void cancelPhochak() {
+//        //given
+//        UserEntity userEntity = new UserEntity();
+//        PostEntity postEntity = new PostEntity();
+//        LikesEntity likesEntity = new LikesEntity();
+//
+//        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
+//        given(postRepository.getReferenceById(anyLong())).willReturn(postEntity);
+//        given(likesRepository.findByUserAndPost(userEntity, postEntity)).willReturn(Optional.of(likesEntity));
+//
+//        //then
+//        likeService.cancelPhochak(0L, 0L);
+//
+//        //then
+//        verify(likesRepository, times(1)).delete(any());
+//    }
+//
+//    @Test
+//    @DisplayName("포착되지 않았던 게시글을 포착 취소하면 NOT_PHOCHAKED 예외가 발생한다")
+//    void cancelPhochak_notPhochaked() {
+//        //given
+//        UserEntity userEntity = new UserEntity();
+//        PostEntity postEntity = new PostEntity();
+//
+//        given(userRepository.getReferenceById(anyLong())).willReturn(userEntity);
+//        given(postRepository.getReferenceById(anyLong())).willReturn(postEntity);
+//        given(likesRepository.findByUserAndPost(userEntity, postEntity)).willReturn(Optional.empty());
+//
+//        //when, then
+//        assertThatExceptionOfType(PhochakException.class).isThrownBy(() -> likeService.cancelPhochak(0L, 0L));
+//        verify(likesRepository, never()).delete(any());
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/deprecated/service/PostServiceTest.java
+++ b/src/test/java/com/nexters/phochak/deprecated/service/PostServiceTest.java
@@ -1,73 +1,73 @@
-package com.nexters.phochak.deprecated.service;
-
-import com.nexters.phochak.common.exception.PhochakException;
-import com.nexters.phochak.common.exception.ResCode;
-import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
-import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
-import com.nexters.phochak.post.application.PostService;
-import com.nexters.phochak.shorts.adapter.out.api.StorageBucketClient;
-import com.nexters.phochak.shorts.application.port.in.PostUploadKeyResponseDto;
-import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-
-@Disabled
-@ExtendWith(MockitoExtension.class)
-class PostServiceTest {
-
-    @InjectMocks
-    PostService postService;
-
-    @Mock
-    StorageBucketClient storageBucketClient;
-    @Mock
-    UserRepository userRepository;
-    @Mock
-    PostRepository postRepository;
-
-    @Test
-    @DisplayName("Presigned URL과 UploadKey 생성에 성공한다")
-    void generateUploadKey() throws MalformedURLException {
-        //given
-        given(storageBucketClient.generatePresignedUrl(any())).willReturn(new URL("http://test.com"));
-
-        //when
-        PostUploadKeyResponseDto result = postService.generateUploadKey("mov");
-
-        //then
-        assertThat(result.uploadKey()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("포스트 주인이 아닌 유저가 삭제를 시도하면 NOT_POST_OWNER 예외가 발생한다")
-    void deletePostByNotPostOwner() {
-        //given
-        UserEntity userEntity = new UserEntity();
-        UserEntity owner = new UserEntity();
-        PostEntity postEntity = PostEntity.builder()
-                        .userEntity(owner)
-                        .build();
-        given(userRepository.getReferenceById(any())).willReturn(userEntity);
-        given(postRepository.findPostFetchJoin(any())).willReturn(Optional.of(postEntity));
-
-        //when, then
-        assertThatThrownBy(() -> postService.delete(0L, 0L))
-                .isInstanceOf(PhochakException.class)
-                .hasMessage(ResCode.NOT_POST_OWNER.getMessage());
-    }
-}
+//package com.nexters.phochak.deprecated.service;
+//
+//import com.nexters.phochak.common.exception.PhochakException;
+//import com.nexters.phochak.common.exception.ResCode;
+//import com.nexters.phochak.post.adapter.out.persistence.PostEntity;
+//import com.nexters.phochak.post.adapter.out.persistence.PostRepository;
+//import com.nexters.phochak.post.application.PostService;
+//import com.nexters.phochak.shorts.adapter.out.api.StorageBucketClient;
+//import com.nexters.phochak.shorts.application.port.in.PostUploadKeyResponseDto;
+//import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
+//import com.nexters.phochak.user.adapter.out.persistence.UserRepository;
+//import org.junit.jupiter.api.Disabled;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.Mock;
+//import org.mockito.junit.jupiter.MockitoExtension;
+//
+//import java.net.MalformedURLException;
+//import java.net.URL;
+//import java.util.Optional;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.BDDMockito.given;
+//
+//@Disabled
+//@ExtendWith(MockitoExtension.class)
+//class PostServiceTest {
+//
+//    @InjectMocks
+//    PostService postService;
+//
+//    @Mock
+//    StorageBucketClient storageBucketClient;
+//    @Mock
+//    UserRepository userRepository;
+//    @Mock
+//    PostRepository postRepository;
+//
+//    @Test
+//    @DisplayName("Presigned URL과 UploadKey 생성에 성공한다")
+//    void generateUploadKey() throws MalformedURLException {
+//        //given
+//        given(storageBucketClient.generatePresignedUrl(any())).willReturn(new URL("http://test.com"));
+//
+//        //when
+//        PostUploadKeyResponseDto result = postService.generateUploadKey("mov");
+//
+//        //then
+//        assertThat(result.uploadKey()).isNotNull();
+//    }
+//
+//    @Test
+//    @DisplayName("포스트 주인이 아닌 유저가 삭제를 시도하면 NOT_POST_OWNER 예외가 발생한다")
+//    void deletePostByNotPostOwner() {
+//        //given
+//        UserEntity userEntity = new UserEntity();
+//        UserEntity owner = new UserEntity();
+//        PostEntity postEntity = PostEntity.builder()
+//                        .userEntity(owner)
+//                        .build();
+//        given(userRepository.getReferenceById(any())).willReturn(userEntity);
+//        given(postRepository.findPostFetchJoin(any())).willReturn(Optional.of(postEntity));
+//
+//        //when, then
+//        assertThatThrownBy(() -> postService.delete(0L, 0L))
+//                .isInstanceOf(PhochakException.class)
+//                .hasMessage(ResCode.NOT_POST_OWNER.getMessage());
+//    }
+//}

--- a/src/test/java/com/nexters/phochak/user/domain/UserFixture.java
+++ b/src/test/java/com/nexters/phochak/user/domain/UserFixture.java
@@ -2,7 +2,6 @@ package com.nexters.phochak.user.domain;
 
 import com.nexters.phochak.notification.adapter.out.persistence.FcmDeviceTokenEntity;
 import com.nexters.phochak.user.adapter.out.persistence.UserEntity;
-import org.assertj.core.util.VisibleForTesting;
 
 import java.time.LocalDateTime;
 
@@ -61,9 +60,8 @@ public class UserFixture {
         return this;
     }
 
-    @VisibleForTesting
     public UserEntity build() {
-        return new UserEntity(
+        return UserEntity.forTest(
                 userId,
                 fcmToken,
                 provider,


### PR DESCRIPTION
❗️ 이슈 번호
close #203 


📝 구현 내용
(가능한 한 자세히 작성해 주시면 감사하겠습니다!)

도메인 객체와 엔티티 객체를 구분하게 되면서, 다음 고민들을 하게 되었습니다.
- 도메인 객체의 생성자 공개를 최소화
- 엔티티 객체를 개발자가 직접 생성하지 못하도록 제한
- Mapper 클래스를 통해 도메인 객체와 엔티티 객체의 자유로운 매핑

그래서 고민하고 적용한 규칙은 다음과 같습니다

- 도메인 객체 생성자
  - 실제 도메인 데이터 `create`를 위해서만 생성자를 제공합니다.
  - 도메인 객체 생성 시에 Spring boot Assert 로 값을 검증합니다.
  - Mapper를 위해 정적 팩토리 메소드 'forMapper'를 제공합니다.

- 엔티티 객체 생성자
  - 오직 Mapper를 위한 생성자만 존재합니다. (개발자가 엔티티 객체를 직접 생성하지 못하게 제한합니다.)
  - 엔티티를 직접 생성할 수 없도록 해당 생성자를 default 접근제어자로 설정했습니다.
  - 유저 객체의 엔티티의 생성자는 테스트를 위해 `@VisibleForTesting` 를 적용한 생성자를 열었습니다.
